### PR TITLE
testing new ideas to improve detection performance

### DIFF
--- a/src/process/detection/CfarDetector1D.cpp
+++ b/src/process/detection/CfarDetector1D.cpp
@@ -58,7 +58,7 @@ std::unique_ptr<Detection> CfarDetector1D::process(Map<std::complex<double>> *x)
       std::vector<int> iTrain;
       for (int k = j-nGuard-nTrain; k < j-nGuard; k++)
       {
-        if (k > 0 && k < nDelayBins)
+        if (k >= 0 && k < nDelayBins)
         {
           iTrain.push_back(k);
         }
@@ -73,6 +73,10 @@ std::unique_ptr<Detection> CfarDetector1D::process(Map<std::complex<double>> *x)
 
       // compute threshold
       int nCells = iTrain.size();
+      if (nCells <= 0)
+      {
+        continue;
+      }
       double alpha = nCells * (pow(pfa, -1.0 / nCells) - 1);
       double trainNoise = 0.0;
       for (int k = 0; k < nCells; k++)

--- a/src/process/detection/Interpolate.cpp
+++ b/src/process/detection/Interpolate.cpp
@@ -34,51 +34,59 @@ std::unique_ptr<Detection> Interpolate::process(Detection *x, Map<std::complex<d
   // loop over every detection
   for (size_t i = 0; i < snr.size(); i++)
   {
+    bool useDelayInterpolation = doDelay;
+    bool useDopplerInterpolation = doDoppler;
     // initialise interpolated values for bool flags
     intDelay = delay[i];
     intDoppler = doppler[i];
     intSnrDelay = snr[i];
     intSnrDoppler = snr[i];
     // interpolate in delay
-    if (doDelay)
+    if (useDelayInterpolation)
     {
       // check not on boundary
       if (delay[i] == indexDelay[0] || delay[i] == indexDelay.back())
       {
-        continue;
+        useDelayInterpolation = false;
       }
-      intSnr[0] = (double)10*std::log10(std::abs(y->data[y->doppler_hz_to_bin(doppler[i])][delay[i]-1-indexDelay[0]]))-y->noisePower;
-      intSnr[1] = (double)10*std::log10(std::abs(y->data[y->doppler_hz_to_bin(doppler[i])][delay[i]-indexDelay[0]]))-y->noisePower;
-      intSnr[2] = (double)10*std::log10(std::abs(y->data[y->doppler_hz_to_bin(doppler[i])][delay[i]+1-indexDelay[0]]))-y->noisePower;
-      // check detection has peak SNR of neighbours
-      if (intSnr[1] < intSnr[0] || intSnr[1] < intSnr[2])
+      if (useDelayInterpolation)
       {
-          std::cout << "Detection dropped (SNR of peak lower)" << std::endl;
-          continue;
+        intSnr[0] = (double)10*std::log10(std::abs(y->data[y->doppler_hz_to_bin(doppler[i])][delay[i]-1-indexDelay[0]]))-y->noisePower;
+        intSnr[1] = (double)10*std::log10(std::abs(y->data[y->doppler_hz_to_bin(doppler[i])][delay[i]-indexDelay[0]]))-y->noisePower;
+        intSnr[2] = (double)10*std::log10(std::abs(y->data[y->doppler_hz_to_bin(doppler[i])][delay[i]+1-indexDelay[0]]))-y->noisePower;
+        // check detection has peak SNR of neighbours
+        if (intSnr[1] < intSnr[0] || intSnr[1] < intSnr[2])
+        {
+            std::cout << "Detection dropped (SNR of peak lower)" << std::endl;
+            continue;
+        }
+        intDelay = (intSnr[0]-intSnr[2])/(2*(intSnr[0]-(2*intSnr[1])+intSnr[2]));
+        intSnrDelay = intSnr[1] - (((intSnr[0]-intSnr[2])*intDelay)/4);
+        intDelay = delay[i] + intDelay;
       }
-      intDelay = (intSnr[0]-intSnr[2])/(2*(intSnr[0]-(2*intSnr[1])+intSnr[2]));
-      intSnrDelay = intSnr[1] - (((intSnr[0]-intSnr[2])*intDelay)/4);
-      intDelay = delay[i] + intDelay;
     }
     // interpolate in Doppler
-    if (doDoppler)
+    if (useDopplerInterpolation)
     {
       // check not on boundary
       if (doppler[i] == indexDoppler[0] || doppler[i] == indexDoppler.back())
       {
-        continue;
+        useDopplerInterpolation = false;
       }
-      intSnr[0] = (double)10*std::log10(std::abs(y->data[y->doppler_hz_to_bin(doppler[i])-1][delay[i]-indexDelay[0]]))-y->noisePower;
-      intSnr[1] = (double)10*std::log10(std::abs(y->data[y->doppler_hz_to_bin(doppler[i])][delay[i]-indexDelay[0]]))-y->noisePower;
-      intSnr[2] = (double)10*std::log10(std::abs(y->data[y->doppler_hz_to_bin(doppler[i])+1][delay[i]-indexDelay[0]]))-y->noisePower;
-      // check detection has peak SNR of neighbours
-      if (intSnr[1] < intSnr[0] || intSnr[1] < intSnr[2])
+      if (useDopplerInterpolation)
       {
-          continue;
+        intSnr[0] = (double)10*std::log10(std::abs(y->data[y->doppler_hz_to_bin(doppler[i])-1][delay[i]-indexDelay[0]]))-y->noisePower;
+        intSnr[1] = (double)10*std::log10(std::abs(y->data[y->doppler_hz_to_bin(doppler[i])][delay[i]-indexDelay[0]]))-y->noisePower;
+        intSnr[2] = (double)10*std::log10(std::abs(y->data[y->doppler_hz_to_bin(doppler[i])+1][delay[i]-indexDelay[0]]))-y->noisePower;
+        // check detection has peak SNR of neighbours
+        if (intSnr[1] < intSnr[0] || intSnr[1] < intSnr[2])
+        {
+            continue;
+        }
+        intDoppler = (intSnr[0]-intSnr[2])/(2*(intSnr[0]-(2*intSnr[1])+intSnr[2]));
+        intSnrDoppler = intSnr[1] - (((intSnr[0]-intSnr[2])*intDoppler)/4);
+        intDoppler = doppler[i] + ((indexDoppler[1]-indexDoppler[0])*intDoppler);
       }
-      intDoppler = (intSnr[0]-intSnr[2])/(2*(intSnr[0]-(2*intSnr[1])+intSnr[2]));
-      intSnrDelay = intSnr[1] - (((intSnr[0]-intSnr[2])*intDoppler)/4);
-      intDoppler = doppler[i] + ((indexDoppler[1]-indexDoppler[0])*intDoppler);
     }
     // store interpolated detections
     delay2.push_back(intDelay);


### PR DESCRIPTION
1. CFAR edge handling and safety in [CfarDetector1D.cpp](vscode-file://vscode-app/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html)
2. Included delay bin 0 as a valid left-side training cell (changed condition from k > 0 to k >= 0 at [CfarDetector1D.cpp:61](vscode-file://vscode-app/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html)).
3. Added a guard to skip thresholding when no training cells are available, preventing invalid alpha computation/divide-by-zero edge behavior at [CfarDetector1D.cpp:76](vscode-file://vscode-app/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html).
4. Interpolation robustness and bug fix in [Interpolate.cpp](vscode-file://vscode-app/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html)
5. Boundary detections are now retained rather than dropped: if a detection is at delay/Doppler boundary, interpolation is skipped for that axis but detection is kept at original coordinates (logic around [Interpolate.cpp:46](vscode-file://vscode-app/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) and [Interpolate.cpp:67](vscode-file://vscode-app/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html)).
6. Fixed Doppler interpolation SNR assignment bug by writing to Doppler SNR variable instead of Delay SNR variable at [Interpolate.cpp:80](vscode-file://vscode-app/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html).
7. Added per-detection local interpolation flags so class-level interpolation settings are not accidentally mutated across detections.