### PR TITLE
Cfar improvements phase b

### DIFF
--- a/config/config-hackrf.yml
+++ b/config/config-hackrf.yml
@@ -35,6 +35,7 @@ process:
     nTrain: 6
     minDelay: 5
     minDoppler: 15
+    cfarMode: "CA" # Available types: CA, CAGO
     nCentroid: 6
   tracker:
     enable: true

--- a/config/config-kraken.yml
+++ b/config/config-kraken.yml
@@ -35,6 +35,7 @@ process:
     nTrain: 6
     minDelay: 5
     minDoppler: 15
+    cfarMode: "CA" # Available types: CA, CAGO
     nCentroid: 6
   tracker:
     enable: true

--- a/config/config-usrp.yml
+++ b/config/config-usrp.yml
@@ -33,6 +33,7 @@ process:
     nTrain: 6
     minDelay: 5
     minDoppler: 15
+    cfarMode: "CA" # Available types: CA, CAGO
     nCentroid: 6
   tracker:
     enable: true

--- a/config/config.yml
+++ b/config/config.yml
@@ -37,6 +37,7 @@ process:
     nTrain: 6
     minDelay: 5
     minDoppler: 15
+    cfarMode: "CA" # Available types: CA, CAGO
     nCentroid: 6
   tracker:
     enable: false

--- a/config/radar4.yml
+++ b/config/radar4.yml
@@ -35,6 +35,7 @@ process:
     nTrain: 6
     minDelay: 5
     minDoppler: 15
+    cfarMode: "CA" # Available types: CA, CAGO
     nCentroid: 6
   tracker:
     enable: true

--- a/src/blah2.cpp
+++ b/src/blah2.cpp
@@ -173,12 +173,28 @@ int main(int argc, char **argv)
   double pfa, minDoppler;
   int8_t nGuard, nTrain;
   int8_t minDelay;
+  std::string cfarModeString = "CA";
+  CfarMode cfarMode = CfarMode::CA;
   tree["process"]["detection"]["pfa"] >> pfa;
   tree["process"]["detection"]["nGuard"] >> nGuard;
   tree["process"]["detection"]["nTrain"] >> nTrain;
   tree["process"]["detection"]["minDelay"] >> minDelay;
   tree["process"]["detection"]["minDoppler"] >> minDoppler;
-  CfarDetector1D *cfarDetector1D = new CfarDetector1D(pfa, nGuard, nTrain, minDelay, minDoppler);
+  auto cfarModeNode = tree["process"]["detection"]["cfarMode"];
+  if (cfarModeNode.valid())
+  {
+    cfarModeNode >> cfarModeString;
+  }
+  if (cfarModeString == "CAGO")
+  {
+    cfarMode = CfarMode::CAGO;
+  }
+  else if (cfarModeString != "CA")
+  {
+    std::cout << "Warning: Unsupported cfarMode '" << cfarModeString << "'. Falling back to CA." << "\n";
+    cfarMode = CfarMode::CA;
+  }
+  CfarDetector1D *cfarDetector1D = new CfarDetector1D(pfa, nGuard, nTrain, minDelay, minDoppler, cfarMode);
   Interpolate *interpolate = new Interpolate(true, true);
 
   // set up process centroid

--- a/src/process/detection/CfarDetector1D.cpp
+++ b/src/process/detection/CfarDetector1D.cpp
@@ -6,7 +6,7 @@
 #include <cmath>
 
 // constructor
-CfarDetector1D::CfarDetector1D(double _pfa, int8_t _nGuard, int8_t _nTrain, int8_t _minDelay, double _minDoppler)
+CfarDetector1D::CfarDetector1D(double _pfa, int8_t _nGuard, int8_t _nTrain, int8_t _minDelay, double _minDoppler, CfarMode _mode)
 {
   // input
   pfa = _pfa;
@@ -14,6 +14,7 @@ CfarDetector1D::CfarDetector1D(double _pfa, int8_t _nGuard, int8_t _nTrain, int8
   nTrain = _nTrain;
   minDelay = _minDelay;
   minDoppler = _minDoppler;
+  mode = _mode;
 }
 
 CfarDetector1D::~CfarDetector1D()
@@ -55,35 +56,103 @@ std::unique_ptr<Detection> CfarDetector1D::process(Map<std::complex<double>> *x)
         continue;
       } 
       // get train cell indices
-      std::vector<int> iTrain;
+      std::vector<int> iTrainLeading;
+      std::vector<int> iTrainTrailing;
       for (int k = j-nGuard-nTrain; k < j-nGuard; k++)
       {
         if (k >= 0 && k < nDelayBins)
         {
-          iTrain.push_back(k);
+          iTrainLeading.push_back(k);
         }
       }
       for (int k = j+nGuard+1; k < j+nGuard+nTrain+1; k++)
       {
         if (k >= 0 && k < nDelayBins)
         {
-          iTrain.push_back(k);
+          iTrainTrailing.push_back(k);
         }
       }
 
       // compute threshold
-      int nCells = iTrain.size();
+      int nLeading = iTrainLeading.size();
+      int nTrailing = iTrainTrailing.size();
+      int nCells = 0;
+      double trainNoise = 0.0;
+
+      if (mode == CfarMode::CA)
+      {
+        nCells = nLeading + nTrailing;
+        if (nCells > 0)
+        {
+          double leadingNoise = 0.0;
+          double trailingNoise = 0.0;
+          for (int k = 0; k < nLeading; k++)
+          {
+            leadingNoise += mapRowSquare[iTrainLeading[k]];
+          }
+          for (int k = 0; k < nTrailing; k++)
+          {
+            trailingNoise += mapRowSquare[iTrainTrailing[k]];
+          }
+          trainNoise = (leadingNoise + trailingNoise) / nCells;
+        }
+      }
+      else
+      {
+        double leadingNoise = 0.0;
+        double trailingNoise = 0.0;
+        double leadingMean = 0.0;
+        double trailingMean = 0.0;
+
+        for (int k = 0; k < nLeading; k++)
+        {
+          leadingNoise += mapRowSquare[iTrainLeading[k]];
+        }
+        for (int k = 0; k < nTrailing; k++)
+        {
+          trailingNoise += mapRowSquare[iTrainTrailing[k]];
+        }
+
+        if (nLeading > 0)
+        {
+          leadingMean = leadingNoise / nLeading;
+        }
+        if (nTrailing > 0)
+        {
+          trailingMean = trailingNoise / nTrailing;
+        }
+
+        if (nLeading == 0 && nTrailing == 0)
+        {
+          nCells = 0;
+        }
+        else if (nLeading == 0)
+        {
+          nCells = nTrailing;
+          trainNoise = trailingMean;
+        }
+        else if (nTrailing == 0)
+        {
+          nCells = nLeading;
+          trainNoise = leadingMean;
+        }
+        else if (leadingMean >= trailingMean)
+        {
+          nCells = nLeading;
+          trainNoise = leadingMean;
+        }
+        else
+        {
+          nCells = nTrailing;
+          trainNoise = trailingMean;
+        }
+      }
+
       if (nCells <= 0)
       {
         continue;
       }
       double alpha = nCells * (pow(pfa, -1.0 / nCells) - 1);
-      double trainNoise = 0.0;
-      for (int k = 0; k < nCells; k++)
-      {
-        trainNoise += mapRowSquare[iTrain[k]];
-      }
-      trainNoise /= nCells;
       double threshold = alpha * trainNoise;
 
       // detection if over threshold
@@ -93,7 +162,8 @@ std::unique_ptr<Detection> CfarDetector1D::process(Map<std::complex<double>> *x)
         doppler.push_back(x->doppler[i]);
         snr.push_back(mapRowSnr[j]);
       }
-      iTrain.clear();
+      iTrainLeading.clear();
+      iTrainTrailing.clear();
     }
     mapRowSquare.clear();
     mapRowSnr.clear();

--- a/src/process/detection/CfarDetector1D.h
+++ b/src/process/detection/CfarDetector1D.h
@@ -14,6 +14,12 @@
 #include <complex>
 #include <memory>
 
+enum class CfarMode
+{
+  CA,
+  CAGO
+};
+
 class CfarDetector1D
 {
 private:
@@ -32,6 +38,9 @@ private:
   /// @brief Minimum absolute Doppler to process detections (Hz).
   double minDoppler;
 
+  /// @brief CFAR mode.
+  CfarMode mode;
+
   /// @brief Pointer to detection data to store result.
   Detection *detection;
 
@@ -42,8 +51,9 @@ public:
   /// @param nTrain Number of single-sided training cells.
   /// @param minDelay Minimum delay to process detections (bins).
   /// @param minDoppler Minimum absolute Doppler to process detections (Hz).
+  /// @param mode CFAR mode.
   /// @return The object.
-  CfarDetector1D(double pfa, int8_t nGuard, int8_t nTrain, int8_t minDelay, double minDoppler);
+  CfarDetector1D(double pfa, int8_t nGuard, int8_t nTrain, int8_t minDelay, double minDoppler, CfarMode mode = CfarMode::CA);
 
   /// @brief Destructor.
   /// @return Void.

--- a/test/unit/process/detection/TestDetectionPhaseA.cpp
+++ b/test/unit/process/detection/TestDetectionPhaseA.cpp
@@ -93,3 +93,91 @@ TEST_CASE("Interpolate_DopplerBoundaryDetectionRetained", "[detection][interpola
   REQUIRE(result->get_nDetections() == 1);
   CHECK_THAT(result->get_doppler().front(), Catch::Matchers::WithinAbs(-1.0, 1e-6));
 }
+
+TEST_CASE("CFAR_CAGO_SuppressesClutterEdgeFalseAlarm", "[detection][cfar][phaseb]")
+{
+  Map<std::complex<double>> map(1, 5);
+  map.delay = {0, 1, 2, 3, 4};
+  map.doppler = {20.0};
+  map.noisePower = 0.0;
+
+  // CUT at delay=2 has moderate power. Leading side is cluttered, trailing
+  // side is quiet.
+  map.data[0][0] = std::complex<double>(0.1, 0.0);
+  map.data[0][1] = std::complex<double>(10.0, 0.0);                  // power 100
+  map.data[0][2] = std::complex<double>(7.745966692, 0.0);           // power 60
+  map.data[0][3] = std::complex<double>(1.0, 0.0);                   // power 1
+  map.data[0][4] = std::complex<double>(0.1, 0.0);
+
+  CfarDetector1D cfarCa(0.5, 0, 1, 0, 0.0, CfarMode::CA);
+  CfarDetector1D cfarCago(0.5, 0, 1, 0, 0.0, CfarMode::CAGO);
+  std::unique_ptr<Detection> caResult = cfarCa.process(&map);
+  std::unique_ptr<Detection> cagoResult = cfarCago.process(&map);
+
+  bool caDetectedCut = false;
+  for (double delay : caResult->get_delay())
+  {
+    if (std::abs(delay - 2.0) < 1e-6)
+    {
+      caDetectedCut = true;
+      break;
+    }
+  }
+
+  bool cagoDetectedCut = false;
+  for (double delay : cagoResult->get_delay())
+  {
+    if (std::abs(delay - 2.0) < 1e-6)
+    {
+      cagoDetectedCut = true;
+      break;
+    }
+  }
+
+  CHECK(caDetectedCut);
+  CHECK(!cagoDetectedCut);
+}
+
+TEST_CASE("CFAR_CAGO_MatchesCAInHomogeneousNoise", "[detection][cfar][phaseb]")
+{
+  Map<std::complex<double>> map(1, 7);
+  map.delay = {0, 1, 2, 3, 4, 5, 6};
+  map.doppler = {20.0};
+  map.noisePower = 0.0;
+
+  // Symmetric local background around CUT at delay=3.
+  map.data[0][0] = std::complex<double>(0.1, 0.0);
+  map.data[0][1] = std::complex<double>(1.0, 0.0);                   // power 1
+  map.data[0][2] = std::complex<double>(1.0, 0.0);                   // power 1
+  map.data[0][3] = std::complex<double>(5.0, 0.0);                   // power 25 (CUT)
+  map.data[0][4] = std::complex<double>(1.0, 0.0);                   // power 1
+  map.data[0][5] = std::complex<double>(1.0, 0.0);                   // power 1
+  map.data[0][6] = std::complex<double>(0.1, 0.0);
+
+  CfarDetector1D cfarCa(0.5, 0, 2, 0, 0.0, CfarMode::CA);
+  CfarDetector1D cfarCago(0.5, 0, 2, 0, 0.0, CfarMode::CAGO);
+  std::unique_ptr<Detection> caResult = cfarCa.process(&map);
+  std::unique_ptr<Detection> cagoResult = cfarCago.process(&map);
+
+  bool caDetectedCut = false;
+  for (double delay : caResult->get_delay())
+  {
+    if (std::abs(delay - 3.0) < 1e-6)
+    {
+      caDetectedCut = true;
+      break;
+    }
+  }
+
+  bool cagoDetectedCut = false;
+  for (double delay : cagoResult->get_delay())
+  {
+    if (std::abs(delay - 3.0) < 1e-6)
+    {
+      cagoDetectedCut = true;
+      break;
+    }
+  }
+
+  CHECK(caDetectedCut == cagoDetectedCut);
+}


### PR DESCRIPTION
This PR is to add CAGO-CFAR detection algorith.

Choose CA-CFAR when...

You are operating in a relatively clear and uniform environment, such as open air or calm sea conditions with minimal interference.

Low computational load and fast processing are top priorities for your system.

Your primary goal is optimal detection in simple, stable clutter backgrounds.

Choose CAGO-CFAR when...

Your radar will encounter clutter edges, such as detecting targets where the sea meets land, or the edge of a weather front.

You need to prevent a sudden surge of false alarms at the boundary between areas of high and low clutter.

You are willing to accept a minor loss in detection sensitivity in homogeneous areas to gain superior robustness at clutter boundaries.