### PR TITLE
Iq test detection harness

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -151,9 +151,43 @@ target_link_libraries(testDetectionPhaseB PRIVATE
 set_target_properties(testDetectionPhaseB PROPERTIES
   RUNTIME_OUTPUT_DIRECTORY "${PROJECT_BINARY_TEST_UNIT_DIR}")
 
+add_executable(testSource
+  test/unit/capture/TestSource.cpp
+  src/capture/Source.cpp
+  src/data/IqData.cpp
+)
+target_link_libraries(testSource PRIVATE
+  Catch2::Catch2WithMain
+)
+set_target_properties(testSource PROPERTIES
+  RUNTIME_OUTPUT_DIRECTORY "${PROJECT_BINARY_TEST_UNIT_DIR}")
+
+add_executable(testDetectionSweep
+  test/comparison/TestDetectionSweep.cpp
+  src/data/IqData.cpp
+  src/data/Map.cpp
+  src/data/Detection.cpp
+  src/process/ambiguity/Ambiguity.cpp
+  src/process/clutter/WienerHopf.cpp
+  src/process/detection/CfarDetector1D.cpp
+  src/process/detection/Centroid.cpp
+  src/process/detection/Interpolate.cpp
+  src/process/meta/HammingNumber.cpp
+)
+target_link_libraries(testDetectionSweep PRIVATE
+  Threads::Threads
+  ryml::ryml
+  armadillo
+  fftw3
+  fftw3_threads
+)
+set_target_properties(testDetectionSweep PROPERTIES
+  RUNTIME_OUTPUT_DIRECTORY "${PROJECT_BINARY_TEST_COMPARISON_DIR}")
+
 # TODO: Unsure if will be using CTest.
 add_test(NAME testAmbiguity COMMAND testAmbiguity)
 add_test(NAME testIqData COMMAND testIqData)
 add_test(NAME testTracker COMMAND testTracker)
+add_test(NAME testSource COMMAND testSource)
 add_test(NAME testDetectionPhaseA COMMAND testDetectionPhaseA)
 add_test(NAME testDetectionPhaseB COMMAND testDetectionPhaseB)

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ A real-time radar which can support various SDR platforms. See a live instance a
 - 2 channel processing for a reference and surveillance signal.
 - Designed to be used with external RF source (for passive radar or active radar).
 - Outputs delay-Doppler maps to a web front-end.
-- Record raw IQ data by pressing spacebar on the web front-end.
+- Record raw IQ data from the detection map pages using the IQ Capture button.
 - Saves delay-Doppler maps in a JSON array.
 
 ## SDR Support

--- a/config/config-hackrf.yml
+++ b/config/config-hackrf.yml
@@ -35,7 +35,7 @@ process:
     nTrain: 6
     minDelay: 5
     minDoppler: 15
-    cfarMode: "CA" # Available types: CA, CAGO
+    cfarMode: "CAGO" # Available types: CA, CAGO
     nCentroid: 6
   tracker:
     enable: true

--- a/config/config-kraken.yml
+++ b/config/config-kraken.yml
@@ -35,7 +35,7 @@ process:
     nTrain: 6
     minDelay: 5
     minDoppler: 15
-    cfarMode: "CA" # Available types: CA, CAGO
+    cfarMode: "CAGO" # Available types: CA, CAGO
     nCentroid: 6
   tracker:
     enable: true

--- a/config/config-usrp.yml
+++ b/config/config-usrp.yml
@@ -33,7 +33,7 @@ process:
     nTrain: 6
     minDelay: 5
     minDoppler: 15
-    cfarMode: "CA" # Available types: CA, CAGO
+    cfarMode: "CAGO" # Available types: CA, CAGO
     nCentroid: 6
   tracker:
     enable: true

--- a/config/config.yml
+++ b/config/config.yml
@@ -37,7 +37,7 @@ process:
     nTrain: 6
     minDelay: 5
     minDoppler: 15
-    cfarMode: "CA" # Available types: CA, CAGO
+    cfarMode: "CAGO" # Available types: CA, CAGO
     nCentroid: 6
   tracker:
     enable: false

--- a/doc/example-deployments/multi-node/README.md
+++ b/doc/example-deployments/multi-node/README.md
@@ -69,7 +69,7 @@ sudo docker compose up -d --build --force-recreate
   - `?api_base=//<host>:<port>` (example: `?api_base=//localhost:3100`)
 - Controller behavior follows the same API targeting rules:
   - API/Stash links on `/controller` are rewritten using the active `api_port`/`api_base` values.
-  - Spacebar capture toggle on `/` calls the API using the same resolved base URL.
+  - IQ Capture buttons on the detection map pages call the API using the same resolved base URL.
 - Example node2 UI URLs:
   - `http://localhost:49153/?api_port=3100`
   - `http://localhost:49153/controller?api_port=3100`

--- a/html/control.js
+++ b/html/control.js
@@ -1,20 +1,128 @@
-$(document).on('keypress', function (e) {
-  if (e.which == 32) {
-    const url = build_api_url('/capture/toggle');
+(function () {
+  var controlRoot = null;
+  var statusBadge = null;
+  var toggleButton = null;
+  var pollId = null;
+  var currentCaptureState = null;
+  var togglePending = false;
 
-    $.getJSON(url, function () { })
+  function normalize_capture_state(value) {
+    if (typeof value === 'boolean') {
+      return value;
+    }
 
-      .done(function (data) {
-        console.log('API worked');
-      })
+    if (typeof value === 'number') {
+      return value !== 0;
+    }
 
-      .fail(function () {
-        console.log('API Fail');
-      })
+    if (typeof value === 'string') {
+      var normalized = value.trim().toLowerCase();
+      if (normalized === 'true') {
+        return true;
+      }
+      if (normalized === 'false') {
+        return false;
+      }
+    }
 
-      .always(function () {
-
-      });
-
+    return null;
   }
-});
+
+  function render_capture_state(captureEnabled, statusText, statusClass) {
+    if (!statusBadge || !toggleButton) {
+      return;
+    }
+
+    currentCaptureState = captureEnabled;
+    statusBadge.className = 'badge ' + statusClass;
+    statusBadge.textContent = statusText;
+
+    if (captureEnabled === true) {
+      toggleButton.className = 'btn btn-sm btn-danger';
+      toggleButton.textContent = 'Stop IQ Capture';
+      toggleButton.setAttribute('aria-pressed', 'true');
+    }
+    else if (captureEnabled === false) {
+      toggleButton.className = 'btn btn-sm btn-success';
+      toggleButton.textContent = 'Start IQ Capture';
+      toggleButton.setAttribute('aria-pressed', 'false');
+    }
+    else {
+      toggleButton.className = 'btn btn-sm btn-outline-secondary';
+      toggleButton.textContent = 'IQ Capture Unavailable';
+      toggleButton.setAttribute('aria-pressed', 'false');
+    }
+
+    toggleButton.disabled = togglePending || captureEnabled === null;
+  }
+
+  function fetch_capture_state() {
+    return $.get(build_api_url('/capture'))
+      .done(function (data) {
+        var captureEnabled = normalize_capture_state(data);
+        if (captureEnabled === null) {
+          render_capture_state(null, 'State Unknown', 'text-bg-warning');
+          return;
+        }
+
+        render_capture_state(
+          captureEnabled,
+          captureEnabled ? 'Capture Started' : 'Capture Stopped',
+          captureEnabled ? 'text-bg-danger' : 'text-bg-secondary'
+        );
+      })
+      .fail(function () {
+        render_capture_state(null, 'API Unreachable', 'text-bg-warning');
+      });
+  }
+
+  function toggle_capture_state() {
+    if (togglePending || currentCaptureState === null) {
+      return;
+    }
+
+    togglePending = true;
+    toggleButton.disabled = true;
+    statusBadge.className = 'badge text-bg-info';
+    statusBadge.textContent = 'Updating...';
+
+    $.getJSON(build_api_url('/capture/toggle'))
+      .done(function () {
+        fetch_capture_state().always(function () {
+          togglePending = false;
+          if (currentCaptureState !== null) {
+            toggleButton.disabled = false;
+          }
+        });
+      })
+      .fail(function () {
+        togglePending = false;
+        render_capture_state(null, 'Toggle Failed', 'text-bg-warning');
+      });
+  }
+
+  function init_capture_control() {
+    controlRoot = document.querySelector('[data-iq-capture-control]');
+    if (!controlRoot) {
+      return;
+    }
+
+    statusBadge = controlRoot.querySelector('[data-iq-capture-status]');
+    toggleButton = controlRoot.querySelector('[data-iq-capture-toggle]');
+    if (!statusBadge || !toggleButton) {
+      return;
+    }
+
+    toggleButton.addEventListener('click', toggle_capture_state);
+    render_capture_state(null, 'Checking...', 'text-bg-secondary');
+    fetch_capture_state();
+    pollId = window.setInterval(fetch_capture_state, 1000);
+    window.addEventListener('beforeunload', function () {
+      if (pollId !== null) {
+        window.clearInterval(pollId);
+      }
+    });
+  }
+
+  $(init_capture_control);
+})();

--- a/html/display/detection/delay-doppler/index.html
+++ b/html/display/detection/delay-doppler/index.html
@@ -14,10 +14,20 @@
   </style>
 </head>
 <body>
-  <div style="height: 100vh; width: 95vw" class="container-fluid">
-    <div style="height: 100vh; width: 95vw" class="row d-flex">
-      <div class="justify-content-center" id="data"></div>
+  <div style="height: 100vh; width: 95vw" class="container-fluid py-2">
+    <div class="d-flex flex-column h-100">
+      <div class="d-flex justify-content-end mb-2">
+        <div class="d-flex flex-wrap align-items-center gap-2 border rounded bg-white px-3 py-2 shadow-sm" data-iq-capture-control>
+          <span class="small text-uppercase text-muted">IQ Capture</span>
+          <span class="badge text-bg-secondary" data-iq-capture-status>Checking...</span>
+          <button type="button" class="btn btn-sm btn-outline-secondary" data-iq-capture-toggle disabled>IQ Capture Unavailable</button>
+        </div>
+      </div>
+      <div class="flex-grow-1">
+        <div class="justify-content-center h-100 w-100" id="data"></div>
+      </div>
     </div>
+  </div>
 </body>
 <script>
   xTitle = "Bistatic Range (km)";
@@ -26,5 +36,6 @@
   yVariable = "doppler";
 </script>
 <script src="../../../js/common.js"></script>
+<script src="../../../control.js"></script>
 <script src="../../../js/plot_detection.js"></script>
 </html>

--- a/html/display/detection/delay/index.html
+++ b/html/display/detection/delay/index.html
@@ -14,10 +14,20 @@
   </style>
 </head>
 <body>
-  <div style="height: 100vh; width: 95vw" class="container-fluid">
-    <div style="height: 100vh; width: 95vw" class="row d-flex">
-      <div class="justify-content-center" id="data"></div>
+  <div style="height: 100vh; width: 95vw" class="container-fluid py-2">
+    <div class="d-flex flex-column h-100">
+      <div class="d-flex justify-content-end mb-2">
+        <div class="d-flex flex-wrap align-items-center gap-2 border rounded bg-white px-3 py-2 shadow-sm" data-iq-capture-control>
+          <span class="small text-uppercase text-muted">IQ Capture</span>
+          <span class="badge text-bg-secondary" data-iq-capture-status>Checking...</span>
+          <button type="button" class="btn btn-sm btn-outline-secondary" data-iq-capture-toggle disabled>IQ Capture Unavailable</button>
+        </div>
+      </div>
+      <div class="flex-grow-1">
+        <div class="justify-content-center h-100 w-100" id="data"></div>
+      </div>
     </div>
+  </div>
 </body>
 <script>
   xTitle = "Timestamp";
@@ -26,5 +36,6 @@
   yVariable = "delay";
 </script>
 <script src="../../../js/common.js"></script>
+<script src="../../../control.js"></script>
 <script src="../../../js/plot_detection.js"></script>
 </html>

--- a/html/display/detection/doppler/index.html
+++ b/html/display/detection/doppler/index.html
@@ -14,10 +14,20 @@
   </style>
 </head>
 <body>
-  <div style="height: 100vh; width: 95vw" class="container-fluid">
-    <div style="height: 100vh; width: 95vw" class="row d-flex">
-      <div class="justify-content-center" id="data"></div>
+  <div style="height: 100vh; width: 95vw" class="container-fluid py-2">
+    <div class="d-flex flex-column h-100">
+      <div class="d-flex justify-content-end mb-2">
+        <div class="d-flex flex-wrap align-items-center gap-2 border rounded bg-white px-3 py-2 shadow-sm" data-iq-capture-control>
+          <span class="small text-uppercase text-muted">IQ Capture</span>
+          <span class="badge text-bg-secondary" data-iq-capture-status>Checking...</span>
+          <button type="button" class="btn btn-sm btn-outline-secondary" data-iq-capture-toggle disabled>IQ Capture Unavailable</button>
+        </div>
+      </div>
+      <div class="flex-grow-1">
+        <div class="justify-content-center h-100 w-100" id="data"></div>
+      </div>
     </div>
+  </div>
 </body>
 <script>
   xTitle = "Timestamp";
@@ -26,5 +36,6 @@
   yVariable = "doppler";
 </script>
 <script src="../../../js/common.js"></script>
+<script src="../../../control.js"></script>
 <script src="../../../js/plot_detection.js"></script>
 </html>

--- a/html/display/map/index.html
+++ b/html/display/map/index.html
@@ -18,8 +18,17 @@
   <div class="container-fluid" style="height: 100vh; width: 95vw">
     <div class="row g-2">
       <div class="col-lg-9">
-        <div style="height: calc(100vh - 72px); width: 100%;" class="row d-flex">
-          <div class="justify-content-center" id="data"></div>
+        <div style="height: calc(100vh - 72px); width: 100%;" class="d-flex flex-column">
+          <div class="d-flex justify-content-end mb-2">
+            <div class="d-flex flex-wrap align-items-center gap-2 border rounded bg-white px-3 py-2 shadow-sm" data-iq-capture-control>
+              <span class="small text-uppercase text-muted">IQ Capture</span>
+              <span class="badge text-bg-secondary" data-iq-capture-status>Checking...</span>
+              <button type="button" class="btn btn-sm btn-outline-secondary" data-iq-capture-toggle disabled>IQ Capture Unavailable</button>
+            </div>
+          </div>
+          <div class="flex-grow-1 d-flex">
+            <div class="justify-content-center h-100 w-100" id="data"></div>
+          </div>
         </div>
       </div>
       <div class="col-lg-3">
@@ -46,5 +55,6 @@
   var urlMap = '/api/map';
 </script>
 <script src="../../js/common.js"></script>
+<script src="../../control.js"></script>
 <script src="../../js/plot_map.js"></script>
 </html>

--- a/html/display/maxhold/index.html
+++ b/html/display/maxhold/index.html
@@ -18,8 +18,17 @@
   <div class="container-fluid" style="height: 100vh; width: 95vw">
     <div class="row g-2">
       <div class="col-lg-9">
-        <div style="height: calc(100vh - 72px); width: 100%;" class="row d-flex">
-          <div class="justify-content-center" id="data"></div>
+        <div style="height: calc(100vh - 72px); width: 100%;" class="d-flex flex-column">
+          <div class="d-flex justify-content-end mb-2">
+            <div class="d-flex flex-wrap align-items-center gap-2 border rounded bg-white px-3 py-2 shadow-sm" data-iq-capture-control>
+              <span class="small text-uppercase text-muted">IQ Capture</span>
+              <span class="badge text-bg-secondary" data-iq-capture-status>Checking...</span>
+              <button type="button" class="btn btn-sm btn-outline-secondary" data-iq-capture-toggle disabled>IQ Capture Unavailable</button>
+            </div>
+          </div>
+          <div class="flex-grow-1 d-flex">
+            <div class="justify-content-center h-100 w-100" id="data"></div>
+          </div>
         </div>
       </div>
       <div class="col-lg-3">
@@ -46,5 +55,6 @@
   var urlMap = '/stash/map';
 </script>
 <script src="../../js/common.js"></script>
+<script src="../../control.js"></script>
 <script src="../../js/plot_map.js"></script>
 </html>

--- a/html/index.html
+++ b/html/index.html
@@ -39,8 +39,17 @@
     </div>
     <div class="row g-2">
       <div class="col-lg-9">
-        <div style="height: 80vh; width: 100%;" class="row d-flex">
-          <div class="justify-content-center" id="data"></div>
+        <div style="height: 80vh; width: 100%;" class="d-flex flex-column">
+          <div class="d-flex justify-content-end mb-2">
+            <div class="d-flex flex-wrap align-items-center gap-2 border rounded bg-white px-3 py-2 shadow-sm" data-iq-capture-control>
+              <span class="small text-uppercase text-muted">IQ Capture</span>
+              <span class="badge text-bg-secondary" data-iq-capture-status>Checking...</span>
+              <button type="button" class="btn btn-sm btn-outline-secondary" data-iq-capture-toggle disabled>IQ Capture Unavailable</button>
+            </div>
+          </div>
+          <div class="flex-grow-1 d-flex">
+            <div class="justify-content-center h-100 w-100" id="data"></div>
+          </div>
         </div>
       </div>
       <div class="col-lg-3">
@@ -67,6 +76,6 @@
   var urlMap = '/api/map';
 </script>
 <script src="js/common.js"></script>
-<script src="js/plot_map.js"></script>
 <script src="control.js"></script>
+<script src="js/plot_map.js"></script>
 </html>

--- a/src/blah2.cpp
+++ b/src/blah2.cpp
@@ -26,8 +26,10 @@
 #include <getopt.h>
 #include <string>
 #include <vector>
+#include <cstdlib>
 #include <fstream>
 #include <sstream>
+#include <exception>
 #include <thread>
 #include <chrono>
 #include <sys/time.h>
@@ -168,8 +170,17 @@ int main(int argc, char **argv)
   IqData *buffer2 = new IqData(bufferSamples);
 
   // run capture
-  std::thread t1([&]{capture->process(buffer1, buffer2, 
-    tree["capture"]["device"], ip_capture, port_capture);
+  std::thread t1([&]{
+    try
+    {
+      capture->process(buffer1, buffer2,
+        tree["capture"]["device"], ip_capture, port_capture);
+    }
+    catch (const std::exception &exception)
+    {
+      std::cerr << "Capture process failed: " << exception.what() << "\n";
+      std::exit(EXIT_FAILURE);
+    }
   });
 
   // set up process CPI

--- a/src/blah2.cpp
+++ b/src/blah2.cpp
@@ -338,6 +338,7 @@ int main(int argc, char **argv)
     saveDetectionPath = savePath + ".detection";
   }
   std::string lastAdsbSavePath;
+  bool adsbCaptureMetadataWritten = false;
   bool warnedAdsbSaveFailure = false;
 
   // set up output timing
@@ -450,23 +451,50 @@ int main(int argc, char **argv)
             jsonAdsb = cachedAdsbJson;
           }
           const bool iqCaptureActive = CAPTURE_POINTER != nullptr && CAPTURE_POINTER->is_saving_iq();
-          const std::string iqSaveFile =
-            (CAPTURE_POINTER != nullptr) ? CAPTURE_POINTER->get_current_iq_save_file() : "";
-          const std::string adsbSavePath = adsb_sidecar_path_from_iq_file(iqSaveFile);
+          const Capture::ActiveIqCapture iqCapture =
+            (CAPTURE_POINTER != nullptr) ? CAPTURE_POINTER->get_active_iq_capture() : Capture::ActiveIqCapture{};
+          const std::string adsbSavePath = adsb_sidecar_path_from_iq_file(iqCapture.file);
           if (adsbSavePath != lastAdsbSavePath)
           {
             lastAdsbSavePath = adsbSavePath;
+            adsbCaptureMetadataWritten = false;
             warnedAdsbSaveFailure = false;
           }
           if (isAdsb && iqCaptureActive && !adsbSavePath.empty())
           {
-            // Keep the ADS-B sidecar aligned one-to-one with each IQ capture file.
-            std::ostringstream adsbSnapshot;
-            adsbSnapshot << "{\"timestamp\":" << time[0]/1000 << ",\"targets\":" << jsonAdsb << "}";
-            if (!append_json_array_entry(adsbSnapshot.str(), adsbSavePath) && !warnedAdsbSaveFailure)
+            bool sidecarReady = true;
+
+            // Persist capture-start metadata once so replay alignment does not
+            // depend on local-time filename parsing.
+            if (!adsbCaptureMetadataWritten)
             {
-              std::cerr << "Warning: Failed to save ADS-B snapshots to " << adsbSavePath << "\n";
-              warnedAdsbSaveFailure = true;
+              std::ostringstream adsbMetadata;
+              adsbMetadata << "{\"captureStartMs\":" << iqCapture.startMs << "}";
+              if (!append_json_array_entry(adsbMetadata.str(), adsbSavePath))
+              {
+                if (!warnedAdsbSaveFailure)
+                {
+                  std::cerr << "Warning: Failed to save ADS-B snapshots to " << adsbSavePath << "\n";
+                  warnedAdsbSaveFailure = true;
+                }
+                sidecarReady = false;
+              }
+              else
+              {
+                adsbCaptureMetadataWritten = true;
+              }
+            }
+
+            if (sidecarReady)
+            {
+              // Keep the ADS-B sidecar aligned one-to-one with each IQ capture file.
+              std::ostringstream adsbSnapshot;
+              adsbSnapshot << "{\"timestamp\":" << time[0]/1000 << ",\"targets\":" << jsonAdsb << "}";
+              if (!append_json_array_entry(adsbSnapshot.str(), adsbSavePath) && !warnedAdsbSaveFailure)
+              {
+                std::cerr << "Warning: Failed to save ADS-B snapshots to " << adsbSavePath << "\n";
+                warnedAdsbSaveFailure = true;
+              }
             }
           }
           socket_adsb->sendData(jsonAdsb);

--- a/src/blah2.cpp
+++ b/src/blah2.cpp
@@ -40,6 +40,7 @@
 #include <mutex>
 #include <limits>
 #include <cmath>
+#include <cstdio>
 
 Capture *CAPTURE_POINTER = NULL;
 std::unique_ptr<Socket> socket_map;
@@ -54,6 +55,8 @@ void signal_callback_handler(int signum);
 void getopt_print_help();
 std::string getopt_process(int argc, char **argv);
 std::string ryml_get_file(const char *filename);
+std::string adsb_sidecar_path_from_iq_file(const std::string &iqFile);
+bool append_json_array_entry(const std::string &json, const std::string &filename);
 uint64_t current_time_ms();
 uint64_t current_time_us();
 void timing_helper(std::vector<std::string>& timing_name, 
@@ -334,6 +337,8 @@ int main(int argc, char **argv)
   {
     saveDetectionPath = savePath + ".detection";
   }
+  std::string lastAdsbSavePath;
+  bool warnedAdsbSaveFailure = false;
 
   // set up output timing
   uint64_t tStart = current_time_ms();
@@ -443,6 +448,26 @@ int main(int argc, char **argv)
           {
             std::lock_guard<std::mutex> lock(adsbMutex);
             jsonAdsb = cachedAdsbJson;
+          }
+          const bool iqCaptureActive = CAPTURE_POINTER != nullptr && CAPTURE_POINTER->is_saving_iq();
+          const std::string iqSaveFile =
+            (CAPTURE_POINTER != nullptr) ? CAPTURE_POINTER->get_current_iq_save_file() : "";
+          const std::string adsbSavePath = adsb_sidecar_path_from_iq_file(iqSaveFile);
+          if (adsbSavePath != lastAdsbSavePath)
+          {
+            lastAdsbSavePath = adsbSavePath;
+            warnedAdsbSaveFailure = false;
+          }
+          if (isAdsb && iqCaptureActive && !adsbSavePath.empty())
+          {
+            // Keep the ADS-B sidecar aligned one-to-one with each IQ capture file.
+            std::ostringstream adsbSnapshot;
+            adsbSnapshot << "{\"timestamp\":" << time[0]/1000 << ",\"targets\":" << jsonAdsb << "}";
+            if (!append_json_array_entry(adsbSnapshot.str(), adsbSavePath) && !warnedAdsbSaveFailure)
+            {
+              std::cerr << "Warning: Failed to save ADS-B snapshots to " << adsbSavePath << "\n";
+              warnedAdsbSaveFailure = true;
+            }
           }
           socket_adsb->sendData(jsonAdsb);
           timing_helper(timing_name, timing_time, time, "output_adsb");
@@ -564,6 +589,77 @@ std::string ryml_get_file(const char *filename)
   std::ostringstream contents;
   contents << in.rdbuf();
   return contents.str();
+}
+
+std::string adsb_sidecar_path_from_iq_file(const std::string &iqFile)
+{
+  if (iqFile.empty())
+  {
+    return "";
+  }
+
+  const std::string extension = ".iq";
+  if (iqFile.size() >= extension.size() &&
+    iqFile.compare(iqFile.size() - extension.size(), extension.size(), extension) == 0)
+  {
+    return iqFile.substr(0, iqFile.size() - extension.size()) + ".adsb";
+  }
+
+  return iqFile + ".adsb";
+}
+
+bool append_json_array_entry(const std::string &json, const std::string &filename)
+{
+  if (FILE *file = std::fopen(filename.c_str(), "r"); file == nullptr)
+  {
+    file = std::fopen(filename.c_str(), "w");
+    if (file == nullptr)
+    {
+      return false;
+    }
+    std::fputs("[]", file);
+    std::fclose(file);
+  }
+  else
+  {
+    std::fclose(file);
+  }
+
+  if (FILE *file = std::fopen(filename.c_str(), "rb+"); file != nullptr)
+  {
+    std::fseek(file, 0, SEEK_SET);
+    if (std::getc(file) != '[')
+    {
+      std::fclose(file);
+      return false;
+    }
+
+    bool isEmpty = false;
+    if (std::getc(file) == ']')
+    {
+      isEmpty = true;
+    }
+
+    std::fseek(file, -1, SEEK_END);
+    if (std::getc(file) != ']')
+    {
+      std::fclose(file);
+      return false;
+    }
+
+    std::fseek(file, -1, SEEK_END);
+    if (!isEmpty)
+    {
+      std::fputc(',', file);
+    }
+
+    std::fwrite(json.c_str(), sizeof(char), json.length(), file);
+    std::fputc(']', file);
+    std::fclose(file);
+    return true;
+  }
+
+  return false;
 }
 
 uint64_t current_time_ms()

--- a/src/blah2.cpp
+++ b/src/blah2.cpp
@@ -353,8 +353,8 @@ int main(int argc, char **argv)
             x->push_back(buffer1->pop_front());
             y->push_back(buffer2->pop_front());      
           }
-          buffer1->unlock();
-          buffer2->unlock();
+          buffer1->unlock_and_notify();
+          buffer2->unlock_and_notify();
           timing_helper(timing_name, timing_time, time, "extract_buffer");
           
           // spectrum

--- a/src/capture/Capture.cpp
+++ b/src/capture/Capture.cpp
@@ -3,6 +3,7 @@
 #include "usrp/Usrp.h"
 #include "hackrf/HackRf.h"
 #include "kraken/Kraken.h"
+#include <chrono>
 #include <iostream>
 #include <thread>
 #include <atomic>
@@ -32,12 +33,17 @@ void Capture::process(IqData *buffer1, IqData *buffer2, c4::yml::NodeRef config,
 
   // capture status thread
   std::atomic<bool> pollCaptureStatus{true};
-  std::thread t1([&]{
+  std::thread captureStatusThread([&]{
     while (pollCaptureStatus.load())
     {
       httplib::Client cli("http://" + ip_capture + ":" 
         + std::to_string(port_capture));
       httplib::Result res = cli.Get("/capture");
+      if (!res)
+      {
+        std::this_thread::sleep_for(std::chrono::seconds(1));
+        continue;
+      }
 
       const bool captureRequested = res->body == "true";
 
@@ -56,7 +62,7 @@ void Capture::process(IqData *buffer1, IqData *buffer2, c4::yml::NodeRef config,
           device->close_file();
         }
       }
-      sleep(1);
+      std::this_thread::sleep_for(std::chrono::seconds(1));
     }
   });
 
@@ -67,9 +73,9 @@ void Capture::process(IqData *buffer1, IqData *buffer2, c4::yml::NodeRef config,
       device->start();
       device->process(buffer1, buffer2);
 
-      // Live HackRF/Kraken capture starts async callbacks and returns here,
-      // so keep the capture-status thread alive for the runtime lifetime.
-      t1.join();
+      // Async capture devices return after arming callbacks, so keep polling
+      // capture state for the runtime lifetime.
+      captureStatusThread.join();
       return;
     }
     else
@@ -80,13 +86,13 @@ void Capture::process(IqData *buffer1, IqData *buffer2, c4::yml::NodeRef config,
   catch (const std::exception &exception)
   {
     pollCaptureStatus.store(false);
-    t1.join();
+    captureStatusThread.join();
     throw std::runtime_error("Capture " + type + " failed: "
       + exception.what());
   }
 
   pollCaptureStatus.store(false);
-  t1.join();
+  captureStatusThread.join();
 }
 
 std::unique_ptr<Source> Capture::factory_source(const std::string& type, c4::yml::NodeRef config)

--- a/src/capture/Capture.cpp
+++ b/src/capture/Capture.cpp
@@ -5,6 +5,8 @@
 #include "kraken/Kraken.h"
 #include <iostream>
 #include <thread>
+#include <atomic>
+#include <stdexcept>
 #include <httplib.h>
 
 // constants
@@ -29,8 +31,9 @@ void Capture::process(IqData *buffer1, IqData *buffer2, c4::yml::NodeRef config,
   device = factory_source(type, config);
 
   // capture status thread
+  std::atomic<bool> pollCaptureStatus{true};
   std::thread t1([&]{
-    while (true)
+    while (pollCaptureStatus.load())
     {
       httplib::Client cli("http://" + ip_capture + ":" 
         + std::to_string(port_capture));
@@ -53,15 +56,27 @@ void Capture::process(IqData *buffer1, IqData *buffer2, c4::yml::NodeRef config,
     }
   });
 
-  if (!replay)
+  try
   {
-    device->start();
-    device->process(buffer1, buffer2);
+    if (!replay)
+    {
+      device->start();
+      device->process(buffer1, buffer2);
+    }
+    else
+    {
+      device->replay(buffer1, buffer2, file, loop);
+    }
   }
-  else
+  catch (const std::exception &exception)
   {
-    device->replay(buffer1, buffer2, file, loop);
+    pollCaptureStatus.store(false);
+    t1.join();
+    throw std::runtime_error("Capture " + type + " failed: "
+      + exception.what());
   }
+
+  pollCaptureStatus.store(false);
   t1.join();
 }
 

--- a/src/capture/Capture.cpp
+++ b/src/capture/Capture.cpp
@@ -25,6 +25,17 @@ Capture::Capture(std::string _type, uint32_t _fs, uint32_t _fc, std::string _pat
   saveIq.store(false);
 }
 
+bool Capture::is_saving_iq() const
+{
+  return saveIq.load();
+}
+
+std::string Capture::get_current_iq_save_file() const
+{
+  std::lock_guard<std::mutex> lock(currentIqSaveFileMutex);
+  return currentIqSaveFile;
+}
+
 void Capture::process(IqData *buffer1, IqData *buffer2, c4::yml::NodeRef config, 
   std::string ip_capture, uint16_t port_capture)
 {
@@ -57,13 +68,21 @@ void Capture::process(IqData *buffer1, IqData *buffer2, c4::yml::NodeRef config,
           if (captureRequested)
           {
             // Open the file before exposing saveIq=true to live callbacks.
-            device->open_file();
+            const std::string iqSaveFile = device->open_file();
+            {
+              std::lock_guard<std::mutex> lock(currentIqSaveFileMutex);
+              currentIqSaveFile = iqSaveFile;
+            }
             saveIq.store(true);
           }
           else
           {
             saveIq.store(false);
             device->close_file();
+            {
+              std::lock_guard<std::mutex> lock(currentIqSaveFileMutex);
+              currentIqSaveFile.clear();
+            }
           }
         }
         std::this_thread::sleep_for(std::chrono::seconds(1));

--- a/src/capture/Capture.cpp
+++ b/src/capture/Capture.cpp
@@ -66,6 +66,11 @@ void Capture::process(IqData *buffer1, IqData *buffer2, c4::yml::NodeRef config,
     {
       device->start();
       device->process(buffer1, buffer2);
+
+      // Live HackRF/Kraken capture starts async callbacks and returns here,
+      // so keep the capture-status thread alive for the runtime lifetime.
+      t1.join();
+      return;
     }
     else
     {

--- a/src/capture/Capture.cpp
+++ b/src/capture/Capture.cpp
@@ -4,6 +4,7 @@
 #include "hackrf/HackRf.h"
 #include "kraken/Kraken.h"
 #include <chrono>
+#include <exception>
 #include <iostream>
 #include <thread>
 #include <atomic>
@@ -21,7 +22,7 @@ Capture::Capture(std::string _type, uint32_t _fs, uint32_t _fc, std::string _pat
   fc = _fc;
   path = _path;
   replay = false;
-  saveIq = false;
+  saveIq.store(false);
 }
 
 void Capture::process(IqData *buffer1, IqData *buffer2, c4::yml::NodeRef config, 
@@ -33,38 +34,61 @@ void Capture::process(IqData *buffer1, IqData *buffer2, c4::yml::NodeRef config,
 
   // capture status thread
   std::atomic<bool> pollCaptureStatus{true};
+  std::exception_ptr captureStatusError;
   std::thread captureStatusThread([&]{
-    while (pollCaptureStatus.load())
+    try
     {
-      httplib::Client cli("http://" + ip_capture + ":" 
-        + std::to_string(port_capture));
-      httplib::Result res = cli.Get("/capture");
-      if (!res)
+      while (pollCaptureStatus.load())
       {
+        httplib::Client cli("http://" + ip_capture + ":" 
+          + std::to_string(port_capture));
+        httplib::Result res = cli.Get("/capture");
+        if (!res)
+        {
+          std::this_thread::sleep_for(std::chrono::seconds(1));
+          continue;
+        }
+
+        const bool captureRequested = res->body == "true";
+
+        // if capture status changed
+        if (captureRequested != saveIq.load())
+        {
+          if (captureRequested)
+          {
+            // Open the file before exposing saveIq=true to live callbacks.
+            device->open_file();
+            saveIq.store(true);
+          }
+          else
+          {
+            saveIq.store(false);
+            device->close_file();
+          }
+        }
         std::this_thread::sleep_for(std::chrono::seconds(1));
-        continue;
       }
-
-      const bool captureRequested = res->body == "true";
-
-      // if capture status changed
-      if (captureRequested != saveIq)
-      {
-        if (captureRequested)
-        {
-          // Open the file before exposing saveIq=true to live callbacks.
-          device->open_file();
-          saveIq = true;
-        }
-        else
-        {
-          saveIq = false;
-          device->close_file();
-        }
-      }
-      std::this_thread::sleep_for(std::chrono::seconds(1));
+    }
+    catch (...)
+    {
+      captureStatusError = std::current_exception();
+      pollCaptureStatus.store(false);
     }
   });
+
+  const auto join_capture_status_thread = [&]() {
+    if (captureStatusThread.joinable())
+    {
+      captureStatusThread.join();
+    }
+  };
+
+  const auto rethrow_capture_status_error = [&]() {
+    if (captureStatusError != nullptr)
+    {
+      std::rethrow_exception(captureStatusError);
+    }
+  };
 
   try
   {
@@ -75,24 +99,26 @@ void Capture::process(IqData *buffer1, IqData *buffer2, c4::yml::NodeRef config,
 
       // Async capture devices return after arming callbacks, so keep polling
       // capture state for the runtime lifetime.
-      captureStatusThread.join();
+      join_capture_status_thread();
+      rethrow_capture_status_error();
       return;
     }
     else
     {
       device->replay(buffer1, buffer2, file, loop);
     }
+
+    pollCaptureStatus.store(false);
+    join_capture_status_thread();
+    rethrow_capture_status_error();
   }
   catch (const std::exception &exception)
   {
     pollCaptureStatus.store(false);
-    captureStatusThread.join();
+    join_capture_status_thread();
     throw std::runtime_error("Capture " + type + " failed: "
       + exception.what());
   }
-
-  pollCaptureStatus.store(false);
-  captureStatusThread.join();
 }
 
 std::unique_ptr<Source> Capture::factory_source(const std::string& type, c4::yml::NodeRef config)

--- a/src/capture/Capture.cpp
+++ b/src/capture/Capture.cpp
@@ -30,10 +30,10 @@ bool Capture::is_saving_iq() const
   return saveIq.load();
 }
 
-std::string Capture::get_current_iq_save_file() const
+Capture::ActiveIqCapture Capture::get_active_iq_capture() const
 {
   std::lock_guard<std::mutex> lock(currentIqSaveFileMutex);
-  return currentIqSaveFile;
+  return {currentIqSaveFile, currentIqCaptureStartMs};
 }
 
 void Capture::process(IqData *buffer1, IqData *buffer2, c4::yml::NodeRef config, 
@@ -69,9 +69,12 @@ void Capture::process(IqData *buffer1, IqData *buffer2, c4::yml::NodeRef config,
           {
             // Open the file before exposing saveIq=true to live callbacks.
             const std::string iqSaveFile = device->open_file();
+            const uint64_t captureStartMs = std::chrono::duration_cast<std::chrono::milliseconds>(
+              std::chrono::system_clock::now().time_since_epoch()).count();
             {
               std::lock_guard<std::mutex> lock(currentIqSaveFileMutex);
               currentIqSaveFile = iqSaveFile;
+              currentIqCaptureStartMs = captureStartMs;
             }
             saveIq.store(true);
           }
@@ -82,6 +85,7 @@ void Capture::process(IqData *buffer1, IqData *buffer2, c4::yml::NodeRef config,
             {
               std::lock_guard<std::mutex> lock(currentIqSaveFileMutex);
               currentIqSaveFile.clear();
+              currentIqCaptureStartMs = 0;
             }
           }
         }

--- a/src/capture/Capture.cpp
+++ b/src/capture/Capture.cpp
@@ -39,16 +39,20 @@ void Capture::process(IqData *buffer1, IqData *buffer2, c4::yml::NodeRef config,
         + std::to_string(port_capture));
       httplib::Result res = cli.Get("/capture");
 
+      const bool captureRequested = res->body == "true";
+
       // if capture status changed
-      if ((res->body == "true") != saveIq)
+      if (captureRequested != saveIq)
       {
-        saveIq = res->body == "true";
-        if (saveIq)
+        if (captureRequested)
         {
+          // Open the file before exposing saveIq=true to live callbacks.
           device->open_file();
+          saveIq = true;
         }
         else
         {
+          saveIq = false;
           device->close_file();
         }
       }

--- a/src/capture/Capture.h
+++ b/src/capture/Capture.h
@@ -10,6 +10,7 @@
 #include <vector>
 #include <atomic>
 #include <memory>
+#include <mutex>
 #include <ryml/ryml.hpp>
 #include <ryml/ryml_std.hpp> // optional header, provided for std:: interop
 #include <c4/format.hpp> // needed for the examples below
@@ -28,6 +29,12 @@ private:
 
   /// @brief True if IQ data to be saved.
   std::atomic<bool> saveIq;
+
+  /// @brief Mutex protecting the active IQ save path.
+  mutable std::mutex currentIqSaveFileMutex;
+
+  /// @brief Full path of the currently active IQ capture file.
+  std::string currentIqSaveFile;
 
   /// @brief True if file replay is enabled.
   bool replay;
@@ -78,6 +85,14 @@ public:
   /// @param file Absolute path of file to replay.
   /// @return Void.
   void set_replay(bool loop, std::string file);
+
+  /// @brief Check whether live IQ capture is currently active.
+  /// @return True when the capture toggle is actively saving IQ samples.
+  bool is_saving_iq() const;
+
+  /// @brief Get the current IQ capture file path.
+  /// @return Full path of the active IQ file, or empty when capture is idle.
+  std::string get_current_iq_save_file() const;
 
 };
 

--- a/src/capture/Capture.h
+++ b/src/capture/Capture.h
@@ -36,6 +36,9 @@ private:
   /// @brief Full path of the currently active IQ capture file.
   std::string currentIqSaveFile;
 
+  /// @brief POSIX ms when the current IQ capture window started.
+  uint64_t currentIqCaptureStartMs = 0;
+
   /// @brief True if file replay is enabled.
   bool replay;
 
@@ -46,6 +49,13 @@ private:
   std::string file;
 
 public:
+
+  /// @brief Active IQ capture window state.
+  struct ActiveIqCapture
+  {
+    std::string file;
+    uint64_t startMs = 0;
+  };
 
   /// @brief Sampling frequency (Hz).
   uint32_t fs;
@@ -90,9 +100,9 @@ public:
   /// @return True when the capture toggle is actively saving IQ samples.
   bool is_saving_iq() const;
 
-  /// @brief Get the current IQ capture file path.
-  /// @return Full path of the active IQ file, or empty when capture is idle.
-  std::string get_current_iq_save_file() const;
+  /// @brief Get the current IQ capture state.
+  /// @return Active IQ capture file path and the explicit capture start time.
+  ActiveIqCapture get_active_iq_capture() const;
 
 };
 

--- a/src/capture/Capture.h
+++ b/src/capture/Capture.h
@@ -8,6 +8,7 @@
 
 #include <string>
 #include <vector>
+#include <atomic>
 #include <memory>
 #include <ryml/ryml.hpp>
 #include <ryml/ryml_std.hpp> // optional header, provided for std:: interop
@@ -26,7 +27,7 @@ private:
   std::string type;
 
   /// @brief True if IQ data to be saved.
-  bool saveIq;
+  std::atomic<bool> saveIq;
 
   /// @brief True if file replay is enabled.
   bool replay;

--- a/src/capture/Source.cpp
+++ b/src/capture/Source.cpp
@@ -117,6 +117,8 @@ void Source::append_blah2_paired_iq_samples(size_t channelIndex, const int8_t *s
 
 void Source::flush_blah2_paired_iq_samples_locked()
 {
+  // Callers already hold pendingSaveMutex, so close_file() cannot interleave
+  // between this open-state check and the eventual write path.
   {
     std::lock_guard<std::mutex> lock(saveIqFileMutex);
     if (!saveIqFile.is_open())
@@ -188,6 +190,7 @@ std::string Source::open_file()
 
 void Source::close_file()
 {
+  // Lock both mutexes together so pending sample flushes cannot race a close.
   std::scoped_lock<std::mutex, std::mutex> lock(pendingSaveMutex, saveIqFileMutex);
   clear_blah2_paired_iq_samples_locked();
   if (saveIqFile.is_open())

--- a/src/capture/Source.cpp
+++ b/src/capture/Source.cpp
@@ -7,13 +7,14 @@
 #include <sstream>
 #include <iomanip>
 #include <limits>
+#include <stdexcept>
 
 Source::Source()
 {
 }
 
 // constructor
-Source::Source(std::string _type, uint32_t _fc, uint32_t _fs, 
+Source::Source(std::string _type, uint32_t _fc, uint32_t _fs,
     std::string _path, bool *_saveIq)
 {
   type = _type;
@@ -46,8 +47,7 @@ void Source::replay_blah2_iq_file(IqData *buffer1, IqData *buffer2,
   std::ifstream replay(file, std::ios::binary);
   if (!replay.is_open())
   {
-    std::cerr << "Error: Can not open replay file: " << file << std::endl;
-    exit(1);
+    throw std::runtime_error("Can not open replay file: " + file);
   }
 
   int16_t samples[4] = {0, 0, 0, 0};
@@ -80,6 +80,76 @@ void Source::replay_blah2_iq_file(IqData *buffer1, IqData *buffer2,
   }
 }
 
+void Source::append_blah2_paired_iq_samples(size_t channelIndex, const int8_t *samples,
+  size_t nComplexSamples)
+{
+  if (channelIndex > 1 || samples == nullptr)
+  {
+    return;
+  }
+
+  std::lock_guard<std::mutex> lock(pendingSaveMutex);
+  if (saveIq == nullptr || !*saveIq)
+  {
+    clear_blah2_paired_iq_samples_locked();
+    return;
+  }
+
+  std::deque<std::complex<float>> &pending = pendingSaveSamples[channelIndex];
+  for (size_t i = 0; i < nComplexSamples; i++)
+  {
+    pending.push_back({static_cast<float>(samples[2 * i]),
+      static_cast<float>(samples[2 * i + 1])});
+  }
+
+  flush_blah2_paired_iq_samples_locked();
+
+  // Keep unpaired backlog bounded if one device callback stream stalls.
+  for (size_t i = 0; i < 2; i++)
+  {
+    std::deque<std::complex<float>> &queuedSamples = pendingSaveSamples[i];
+    while (queuedSamples.size() > maxPendingBlah2PairedIqSamples)
+    {
+      queuedSamples.pop_front();
+    }
+  }
+}
+
+void Source::flush_blah2_paired_iq_samples_locked()
+{
+  {
+    std::lock_guard<std::mutex> lock(saveIqFileMutex);
+    if (!saveIqFile.is_open())
+    {
+      return;
+    }
+  }
+
+  const size_t nPaired = std::min(pendingSaveSamples[0].size(), pendingSaveSamples[1].size());
+  if (nPaired == 0)
+  {
+    return;
+  }
+
+  std::vector<std::complex<float>> reference(nPaired);
+  std::vector<std::complex<float>> surveillance(nPaired);
+  for (size_t i = 0; i < nPaired; i++)
+  {
+    reference[i] = pendingSaveSamples[0].front();
+    pendingSaveSamples[0].pop_front();
+    surveillance[i] = pendingSaveSamples[1].front();
+    pendingSaveSamples[1].pop_front();
+  }
+
+  write_blah2_iq_samples(reference.data(), surveillance.data(), nPaired);
+}
+
+void Source::clear_blah2_paired_iq_samples_locked()
+{
+  pendingSaveSamples[0].clear();
+  pendingSaveSamples[1].clear();
+}
+
 std::string Source::open_file()
 {
   // get string of timestamp in YYYYmmdd-HHMMSS
@@ -92,17 +162,26 @@ std::string Source::open_file()
 
   // create file path
   std::string typeLower = type;
-  std::transform(typeLower.begin(), typeLower.end(), 
+  std::transform(typeLower.begin(), typeLower.end(),
     typeLower.begin(), ::tolower);
   std::string file = path + timestamp + "." + typeLower + ".iq";
 
-  saveIqFile.open(file, std::ios::binary);
-
-  if (!saveIqFile.is_open())
   {
-    std::cerr << "Error: Can not open file: " << file << std::endl;
-    exit(1);
+    std::lock_guard<std::mutex> lock(saveIqFileMutex);
+    saveIqFile.open(file, std::ios::binary);
+
+    if (!saveIqFile.is_open())
+    {
+      std::cerr << "Error: Can not open file: " << file << std::endl;
+      exit(1);
+    }
   }
+
+  {
+    std::lock_guard<std::mutex> lock(pendingSaveMutex);
+    flush_blah2_paired_iq_samples_locked();
+  }
+
   std::cout << "Ready to record IQ to file: " << file << std::endl;
 
   return file;
@@ -110,6 +189,8 @@ std::string Source::open_file()
 
 void Source::close_file()
 {
+  std::scoped_lock<std::mutex, std::mutex> lock(pendingSaveMutex, saveIqFileMutex);
+  clear_blah2_paired_iq_samples_locked();
   if (saveIqFile.is_open())
   {
     saveIqFile.close();

--- a/src/capture/Source.cpp
+++ b/src/capture/Source.cpp
@@ -6,6 +6,7 @@
 #include <ctime>
 #include <sstream>
 #include <iomanip>
+#include <limits>
 
 Source::Source()
 {
@@ -20,6 +21,63 @@ Source::Source(std::string _type, uint32_t _fc, uint32_t _fs,
   fs = _fs;
   path = _path;
   saveIq = _saveIq;
+}
+
+int16_t Source::clamp_blah2_iq_component(double value)
+{
+  if (!std::isfinite(value))
+  {
+    return 0;
+  }
+  if (value > static_cast<double>(std::numeric_limits<int16_t>::max()))
+  {
+    return std::numeric_limits<int16_t>::max();
+  }
+  if (value < static_cast<double>(std::numeric_limits<int16_t>::min()))
+  {
+    return std::numeric_limits<int16_t>::min();
+  }
+  return static_cast<int16_t>(std::lround(value));
+}
+
+void Source::replay_blah2_iq_file(IqData *buffer1, IqData *buffer2,
+  const std::string &file, bool loop)
+{
+  std::ifstream replay(file, std::ios::binary);
+  if (!replay.is_open())
+  {
+    std::cerr << "Error: Can not open replay file: " << file << std::endl;
+    exit(1);
+  }
+
+  int16_t samples[4] = {0, 0, 0, 0};
+  while (true)
+  {
+    if (!replay.read(reinterpret_cast<char *>(samples), sizeof(samples)))
+    {
+      if (!loop)
+      {
+        break;
+      }
+
+      replay.clear();
+      replay.seekg(0, std::ios::beg);
+      if (!replay.read(reinterpret_cast<char *>(samples), sizeof(samples)))
+      {
+        break;
+      }
+    }
+
+    buffer1->wait_for_max_length(buffer1->get_n() - 1);
+    buffer2->wait_for_max_length(buffer2->get_n() - 1);
+
+    buffer1->lock();
+    buffer2->lock();
+    buffer1->push_back({static_cast<double>(samples[0]), static_cast<double>(samples[1])});
+    buffer2->push_back({static_cast<double>(samples[2]), static_cast<double>(samples[3])});
+    buffer1->unlock_and_notify();
+    buffer2->unlock_and_notify();
+  }
 }
 
 std::string Source::open_file()
@@ -52,7 +110,7 @@ std::string Source::open_file()
 
 void Source::close_file()
 {
-  if (!saveIqFile.is_open())
+  if (saveIqFile.is_open())
   {
     saveIqFile.close();
   }

--- a/src/capture/Source.cpp
+++ b/src/capture/Source.cpp
@@ -15,7 +15,7 @@ Source::Source()
 
 // constructor
 Source::Source(std::string _type, uint32_t _fc, uint32_t _fs,
-    std::string _path, bool *_saveIq)
+  std::string _path, std::atomic<bool> *_saveIq)
 {
   type = _type;
   fc = _fc;
@@ -89,7 +89,7 @@ void Source::append_blah2_paired_iq_samples(size_t channelIndex, const int8_t *s
   }
 
   std::lock_guard<std::mutex> lock(pendingSaveMutex);
-  if (saveIq == nullptr || !*saveIq)
+  if (saveIq == nullptr || !saveIq->load())
   {
     clear_blah2_paired_iq_samples_locked();
     return;
@@ -172,8 +172,7 @@ std::string Source::open_file()
 
     if (!saveIqFile.is_open())
     {
-      std::cerr << "Error: Can not open file: " << file << std::endl;
-      exit(1);
+      throw std::runtime_error("Can not open file: " + file);
     }
   }
 

--- a/src/capture/Source.h
+++ b/src/capture/Source.h
@@ -36,7 +36,7 @@ protected:
   std::string path;
 
   /// @brief True if IQ data to be saved.
-  bool *saveIq;
+  std::atomic<bool> *saveIq;
 
   /// @brief File stream to save IQ data.
   std::ofstream saveIqFile;
@@ -139,7 +139,7 @@ public:
   /// @param path Absolute path to IQ save location.
   /// @return The object.
   Source(std::string type, uint32_t fc, uint32_t fs,
-    std::string path, bool *saveIq);
+    std::string path, std::atomic<bool> *saveIq);
 
   /// @brief Implement the capture process.
   /// @param buffer1 Buffer for reference samples.

--- a/src/capture/Source.h
+++ b/src/capture/Source.h
@@ -11,8 +11,10 @@
 #include <cmath>
 #include <complex>
 #include <cstddef>
+#include <deque>
 #include <fstream>
 #include <iostream>
+#include <mutex>
 #include <vector>
 #include <atomic>
 #include "data/IqData.h"
@@ -39,6 +41,18 @@ protected:
   /// @brief File stream to save IQ data.
   std::ofstream saveIqFile;
 
+  /// @brief Protects IQ file open/close/write operations.
+  std::mutex saveIqFileMutex;
+
+  /// @brief Pending channel-aligned save samples waiting to be paired.
+  std::deque<std::complex<float>> pendingSaveSamples[2];
+
+  /// @brief Protects access to pending paired save samples.
+  std::mutex pendingSaveMutex;
+
+  /// @brief Maximum unpaired IQ samples retained per channel before dropping oldest.
+  static constexpr size_t maxPendingBlah2PairedIqSamples = 1024 * 1024;
+
   /// @brief Clamp a numeric IQ component into the canonical Blah2 int16 file range.
   /// @param value Numeric sample component.
   /// @return Saturated int16 sample component.
@@ -53,33 +67,61 @@ protected:
   void replay_blah2_iq_file(IqData *buffer1, IqData *buffer2,
     const std::string &file, bool loop);
 
+  /// @brief Append paired int8 IQ samples awaiting canonical file writes.
+  /// @param channelIndex Zero-based channel index.
+  /// @param samples Pointer to interleaved IQ byte samples.
+  /// @param nComplexSamples Number of IQ samples in this callback.
+  /// @return Void.
+  void append_blah2_paired_iq_samples(size_t channelIndex, const int8_t *samples,
+    size_t nComplexSamples);
+
+  /// @brief Flush paired callback samples into the canonical Blah2 IQ file.
+  /// @return Void.
+  void flush_blah2_paired_iq_samples_locked();
+
+  /// @brief Clear any unpaired callback save samples.
+  /// @return Void.
+  void clear_blah2_paired_iq_samples_locked();
+
   /// @brief Write canonical Blah2 IQ samples to disk.
   /// @details Samples are stored as interleaved int16 tuples [refI, refQ, survI, survQ].
   /// @param reference Pointer to reference-channel samples.
   /// @param surveillance Pointer to surveillance-channel samples.
   /// @param nSamples Number of channel-paired samples to write.
+  /// @param scale Scale factor applied before clamping to int16.
   /// @return Void.
   template <typename T>
   void write_blah2_iq_samples(const std::complex<T> *reference,
-    const std::complex<T> *surveillance, size_t nSamples)
+    const std::complex<T> *surveillance, size_t nSamples, double scale = 1.0)
   {
-    if (!saveIqFile.is_open() || reference == nullptr || surveillance == nullptr || nSamples == 0)
+    if (reference == nullptr || surveillance == nullptr || nSamples == 0)
     {
       return;
     }
 
-    std::vector<int16_t> interleaved;
-    interleaved.reserve(nSamples * 4);
+    thread_local std::vector<int16_t> interleavedScratch;
+    interleavedScratch.resize(nSamples * 4);
     for (size_t i = 0; i < nSamples; i++)
     {
-      interleaved.push_back(clamp_blah2_iq_component(reference[i].real()));
-      interleaved.push_back(clamp_blah2_iq_component(reference[i].imag()));
-      interleaved.push_back(clamp_blah2_iq_component(surveillance[i].real()));
-      interleaved.push_back(clamp_blah2_iq_component(surveillance[i].imag()));
+      const size_t offset = i * 4;
+      interleavedScratch[offset] = clamp_blah2_iq_component(
+        scale * static_cast<double>(reference[i].real()));
+      interleavedScratch[offset + 1] = clamp_blah2_iq_component(
+        scale * static_cast<double>(reference[i].imag()));
+      interleavedScratch[offset + 2] = clamp_blah2_iq_component(
+        scale * static_cast<double>(surveillance[i].real()));
+      interleavedScratch[offset + 3] = clamp_blah2_iq_component(
+        scale * static_cast<double>(surveillance[i].imag()));
     }
 
-    saveIqFile.write(reinterpret_cast<const char *>(interleaved.data()),
-      static_cast<std::streamsize>(interleaved.size() * sizeof(int16_t)));
+    std::lock_guard<std::mutex> lock(saveIqFileMutex);
+    if (!saveIqFile.is_open())
+    {
+      return;
+    }
+
+    saveIqFile.write(reinterpret_cast<const char *>(interleavedScratch.data()),
+      static_cast<std::streamsize>(interleavedScratch.size() * sizeof(int16_t)));
     if (!saveIqFile)
     {
       std::cerr << "Error: failed to write Blah2 IQ samples" << std::endl;
@@ -96,7 +138,7 @@ public:
   /// @param fc Center frequency (Hz).
   /// @param path Absolute path to IQ save location.
   /// @return The object.
-  Source(std::string type, uint32_t fc, uint32_t fs, 
+  Source(std::string type, uint32_t fc, uint32_t fs,
     std::string path, bool *saveIq);
 
   /// @brief Implement the capture process.
@@ -119,7 +161,7 @@ public:
   /// @param file Path to file to replay data from.
   /// @param loop True if samples should loop at EOF.
   /// @return Void.
-  virtual void replay(IqData *buffer1, IqData *buffer2, 
+  virtual void replay(IqData *buffer1, IqData *buffer2,
     std::string file, bool loop) = 0;
 
   /// @brief Open a new file to record IQ.

--- a/src/capture/Source.h
+++ b/src/capture/Source.h
@@ -8,7 +8,11 @@
 
 #include <string>
 #include <stdint.h>
+#include <cmath>
+#include <complex>
+#include <cstddef>
 #include <fstream>
+#include <vector>
 #include <atomic>
 #include "data/IqData.h"
 
@@ -33,6 +37,53 @@ protected:
 
   /// @brief File stream to save IQ data.
   std::ofstream saveIqFile;
+
+  /// @brief Clamp a numeric IQ component into the canonical Blah2 int16 file range.
+  /// @param value Numeric sample component.
+  /// @return Saturated int16 sample component.
+  static int16_t clamp_blah2_iq_component(double value);
+
+  /// @brief Replay a canonical Blah2 two-channel IQ file.
+  /// @param buffer1 Pointer to reference buffer.
+  /// @param buffer2 Pointer to surveillance buffer.
+  /// @param file Path to file to replay data from.
+  /// @param loop True if samples should loop at EOF.
+  /// @return Void.
+  void replay_blah2_iq_file(IqData *buffer1, IqData *buffer2,
+    const std::string &file, bool loop);
+
+  /// @brief Write canonical Blah2 IQ samples to disk.
+  /// @details Samples are stored as interleaved int16 tuples [refI, refQ, survI, survQ].
+  /// @param reference Pointer to reference-channel samples.
+  /// @param surveillance Pointer to surveillance-channel samples.
+  /// @param nSamples Number of channel-paired samples to write.
+  /// @return Void.
+  template <typename T>
+  void write_blah2_iq_samples(const std::complex<T> *reference,
+    const std::complex<T> *surveillance, size_t nSamples)
+  {
+    if (!saveIqFile.is_open() || reference == nullptr || surveillance == nullptr || nSamples == 0)
+    {
+      return;
+    }
+
+    std::vector<int16_t> interleaved;
+    interleaved.reserve(nSamples * 4);
+    for (size_t i = 0; i < nSamples; i++)
+    {
+      interleaved.push_back(clamp_blah2_iq_component(reference[i].real()));
+      interleaved.push_back(clamp_blah2_iq_component(reference[i].imag()));
+      interleaved.push_back(clamp_blah2_iq_component(surveillance[i].real()));
+      interleaved.push_back(clamp_blah2_iq_component(surveillance[i].imag()));
+    }
+
+    saveIqFile.write(reinterpret_cast<const char *>(interleaved.data()),
+      static_cast<std::streamsize>(interleaved.size() * sizeof(int16_t)));
+    if (!saveIqFile)
+    {
+      std::cerr << "Error: failed to write Blah2 IQ samples" << std::endl;
+    }
+  }
 
 public:
 
@@ -61,7 +112,7 @@ public:
   /// @return Void.
   virtual void stop() = 0;
 
-  /// @brief Implement replay function on RSPduo.
+  /// @brief Replay a Blah2 two-channel IQ file.
   /// @param buffer1 Pointer to reference buffer.
   /// @param buffer2 Pointer to surveillance buffer.
   /// @param file Path to file to replay data from.
@@ -72,7 +123,8 @@ public:
 
   /// @brief Open a new file to record IQ.
   /// @details First creates a new file from current timestamp.
-  /// Files are of format <path>.<type>.iq.
+  /// Files are of format <path><timestamp>.<type>.iq using Blah2's canonical
+  /// interleaved two-channel int16 sample layout.
   /// @return String of full path to file.
   std::string open_file();
 

--- a/src/capture/Source.h
+++ b/src/capture/Source.h
@@ -12,6 +12,7 @@
 #include <complex>
 #include <cstddef>
 #include <fstream>
+#include <iostream>
 #include <vector>
 #include <atomic>
 #include "data/IqData.h"

--- a/src/capture/hackrf/HackRf.cpp
+++ b/src/capture/hackrf/HackRf.cpp
@@ -1,5 +1,6 @@
 #include "HackRf.h"
 
+#include <algorithm>
 #include <iostream>
 #include <stdexcept>
 #include <unordered_set>
@@ -145,7 +146,58 @@ int HackRf::rx_callback(hackrf_transfer* transfer)
 void HackRf::append_save_samples(size_t channelIndex, const int8_t *samples,
   size_t nComplexSamples)
 {
-  append_blah2_paired_iq_samples(channelIndex, samples, nComplexSamples);
+  if (channelIndex > 1 || samples == nullptr)
+  {
+    return;
+  }
+
+  std::lock_guard<std::mutex> lock(pendingSaveMutex);
+  if (!*saveIq)
+  {
+    clear_pending_save_samples_locked();
+    return;
+  }
+
+  std::deque<std::complex<float>> &pending = pendingSaveSamples[channelIndex];
+  for (size_t i = 0; i < nComplexSamples; i++)
+  {
+    pending.push_back({static_cast<float>(samples[2 * i]),
+      static_cast<float>(samples[2 * i + 1])});
+  }
+
+  flush_paired_save_samples_locked();
+}
+
+void HackRf::flush_paired_save_samples_locked()
+{
+  if (!saveIqFile.is_open())
+  {
+    return;
+  }
+
+  const size_t nPaired = std::min(pendingSaveSamples[0].size(), pendingSaveSamples[1].size());
+  if (nPaired == 0)
+  {
+    return;
+  }
+
+  std::vector<std::complex<float>> reference(nPaired);
+  std::vector<std::complex<float>> surveillance(nPaired);
+  for (size_t i = 0; i < nPaired; i++)
+  {
+    reference[i] = pendingSaveSamples[0].front();
+    pendingSaveSamples[0].pop_front();
+    surveillance[i] = pendingSaveSamples[1].front();
+    pendingSaveSamples[1].pop_front();
+  }
+
+  write_blah2_iq_samples(reference.data(), surveillance.data(), nPaired);
+}
+
+void HackRf::clear_pending_save_samples_locked()
+{
+  pendingSaveSamples[0].clear();
+  pendingSaveSamples[1].clear();
 }
 
 void HackRf::replay(IqData *buffer1, IqData *buffer2, std::string _file, bool _loop)

--- a/src/capture/hackrf/HackRf.cpp
+++ b/src/capture/hackrf/HackRf.cpp
@@ -6,7 +6,7 @@
 
 // constructor
 HackRf::HackRf(std::string _type, uint32_t _fc, uint32_t _fs, 
-  std::string _path, bool *_saveIq, std::vector<std::string> _serial,
+  std::string _path, std::atomic<bool> *_saveIq, std::vector<std::string> _serial,
   std::vector<uint32_t> _gainLna, std::vector<uint32_t> _gainVga, 
   std::vector<bool> _ampEnable)
     : Source(_type, _fc, _fs, _path, _saveIq)

--- a/src/capture/hackrf/HackRf.cpp
+++ b/src/capture/hackrf/HackRf.cpp
@@ -1,6 +1,5 @@
 #include "HackRf.h"
 
-#include <algorithm>
 #include <iostream>
 #include <stdexcept>
 #include <unordered_set>
@@ -146,58 +145,7 @@ int HackRf::rx_callback(hackrf_transfer* transfer)
 void HackRf::append_save_samples(size_t channelIndex, const int8_t *samples,
   size_t nComplexSamples)
 {
-  if (channelIndex > 1 || samples == nullptr)
-  {
-    return;
-  }
-
-  std::lock_guard<std::mutex> lock(pendingSaveMutex);
-  if (!*saveIq)
-  {
-    clear_pending_save_samples_locked();
-    return;
-  }
-
-  std::deque<std::complex<float>> &pending = pendingSaveSamples[channelIndex];
-  for (size_t i = 0; i < nComplexSamples; i++)
-  {
-    pending.push_back({static_cast<float>(samples[2 * i]),
-      static_cast<float>(samples[2 * i + 1])});
-  }
-
-  flush_paired_save_samples_locked();
-}
-
-void HackRf::flush_paired_save_samples_locked()
-{
-  if (!saveIqFile.is_open())
-  {
-    return;
-  }
-
-  const size_t nPaired = std::min(pendingSaveSamples[0].size(), pendingSaveSamples[1].size());
-  if (nPaired == 0)
-  {
-    return;
-  }
-
-  std::vector<std::complex<float>> reference(nPaired);
-  std::vector<std::complex<float>> surveillance(nPaired);
-  for (size_t i = 0; i < nPaired; i++)
-  {
-    reference[i] = pendingSaveSamples[0].front();
-    pendingSaveSamples[0].pop_front();
-    surveillance[i] = pendingSaveSamples[1].front();
-    pendingSaveSamples[1].pop_front();
-  }
-
-  write_blah2_iq_samples(reference.data(), surveillance.data(), nPaired);
-}
-
-void HackRf::clear_pending_save_samples_locked()
-{
-  pendingSaveSamples[0].clear();
-  pendingSaveSamples[1].clear();
+  append_blah2_paired_iq_samples(channelIndex, samples, nComplexSamples);
 }
 
 void HackRf::replay(IqData *buffer1, IqData *buffer2, std::string _file, bool _loop)

--- a/src/capture/hackrf/HackRf.cpp
+++ b/src/capture/hackrf/HackRf.cpp
@@ -1,5 +1,6 @@
 #include "HackRf.h"
 
+#include <algorithm>
 #include <iostream>
 #include <complex>
 #include <stdexcept>
@@ -106,17 +107,25 @@ void HackRf::stop()
 
 void HackRf::process(IqData *buffer1, IqData *buffer2)
 {
+    callbackContexts[0].device = this;
+    callbackContexts[0].buffer = buffer1;
+    callbackContexts[0].channelIndex = 0;
+    callbackContexts[1].device = this;
+    callbackContexts[1].buffer = buffer2;
+    callbackContexts[1].channelIndex = 1;
+
     int status;
-    status = hackrf_start_rx(dev[1], rx_callback, buffer2);
+    status = hackrf_start_rx(dev[1], rx_callback, &callbackContexts[1]);
     check_status(status, "Failed to start RX streaming.");
-    status = hackrf_start_rx(dev[0], rx_callback, buffer1);
+    status = hackrf_start_rx(dev[0], rx_callback, &callbackContexts[0]);
     check_status(status, "Failed to start RX streaming.");
 }
 
 int HackRf::rx_callback(hackrf_transfer* transfer)
 {
-  IqData* buffer_blah2 = (IqData*)transfer->rx_ctx;
-  int8_t* buffer_hackrf = (int8_t*) transfer->buffer;
+  CallbackContext *context = static_cast<CallbackContext *>(transfer->rx_ctx);
+  IqData *buffer_blah2 = context->buffer;
+  int8_t *buffer_hackrf = reinterpret_cast<int8_t *>(transfer->buffer);
 
   buffer_blah2->lock();
 
@@ -129,11 +138,71 @@ int HackRf::rx_callback(hackrf_transfer* transfer)
 
   buffer_blah2->unlock_and_notify();
 
+  context->device->append_save_samples(context->channelIndex, buffer_hackrf,
+    static_cast<size_t>(transfer->buffer_length / 2));
+
   return 0;
+}
+
+void HackRf::append_save_samples(size_t channelIndex, const int8_t *samples,
+  size_t nComplexSamples)
+{
+  if (channelIndex > 1 || samples == nullptr)
+  {
+    return;
+  }
+
+  std::lock_guard<std::mutex> lock(pendingSaveMutex);
+  if (!*saveIq)
+  {
+    clear_pending_save_samples_locked();
+    return;
+  }
+
+  std::deque<std::complex<float>> &pending = pendingSaveSamples[channelIndex];
+  for (size_t i = 0; i < nComplexSamples; i++)
+  {
+    pending.push_back({static_cast<float>(samples[2 * i]),
+      static_cast<float>(samples[2 * i + 1])});
+  }
+
+  flush_paired_save_samples_locked();
+}
+
+void HackRf::flush_paired_save_samples_locked()
+{
+  if (!saveIqFile.is_open())
+  {
+    return;
+  }
+
+  const size_t nPaired = std::min(pendingSaveSamples[0].size(), pendingSaveSamples[1].size());
+  if (nPaired == 0)
+  {
+    return;
+  }
+
+  std::vector<std::complex<float>> reference(nPaired);
+  std::vector<std::complex<float>> surveillance(nPaired);
+  for (size_t i = 0; i < nPaired; i++)
+  {
+    reference[i] = pendingSaveSamples[0].front();
+    pendingSaveSamples[0].pop_front();
+    surveillance[i] = pendingSaveSamples[1].front();
+    pendingSaveSamples[1].pop_front();
+  }
+
+  write_blah2_iq_samples(reference.data(), surveillance.data(), nPaired);
+}
+
+void HackRf::clear_pending_save_samples_locked()
+{
+  pendingSaveSamples[0].clear();
+  pendingSaveSamples[1].clear();
 }
 
 void HackRf::replay(IqData *buffer1, IqData *buffer2, std::string _file, bool _loop)
 {
-  return;
+  replay_blah2_iq_file(buffer1, buffer2, _file, _loop);
 }
 

--- a/src/capture/hackrf/HackRf.cpp
+++ b/src/capture/hackrf/HackRf.cpp
@@ -1,8 +1,6 @@
 #include "HackRf.h"
 
-#include <algorithm>
 #include <iostream>
-#include <complex>
 #include <stdexcept>
 #include <unordered_set>
 
@@ -148,38 +146,6 @@ void HackRf::append_save_samples(size_t channelIndex, const int8_t *samples,
   size_t nComplexSamples)
 {
   append_blah2_paired_iq_samples(channelIndex, samples, nComplexSamples);
-}
-
-void HackRf::flush_paired_save_samples_locked()
-{
-  if (!saveIqFile.is_open())
-  {
-    return;
-  }
-
-  const size_t nPaired = std::min(pendingSaveSamples[0].size(), pendingSaveSamples[1].size());
-  if (nPaired == 0)
-  {
-    return;
-  }
-
-  std::vector<std::complex<float>> reference(nPaired);
-  std::vector<std::complex<float>> surveillance(nPaired);
-  for (size_t i = 0; i < nPaired; i++)
-  {
-    reference[i] = pendingSaveSamples[0].front();
-    pendingSaveSamples[0].pop_front();
-    surveillance[i] = pendingSaveSamples[1].front();
-    pendingSaveSamples[1].pop_front();
-  }
-
-  write_blah2_iq_samples(reference.data(), surveillance.data(), nPaired);
-}
-
-void HackRf::clear_pending_save_samples_locked()
-{
-  pendingSaveSamples[0].clear();
-  pendingSaveSamples[1].clear();
 }
 
 void HackRf::replay(IqData *buffer1, IqData *buffer2, std::string _file, bool _loop)

--- a/src/capture/hackrf/HackRf.cpp
+++ b/src/capture/hackrf/HackRf.cpp
@@ -147,26 +147,7 @@ int HackRf::rx_callback(hackrf_transfer* transfer)
 void HackRf::append_save_samples(size_t channelIndex, const int8_t *samples,
   size_t nComplexSamples)
 {
-  if (channelIndex > 1 || samples == nullptr)
-  {
-    return;
-  }
-
-  std::lock_guard<std::mutex> lock(pendingSaveMutex);
-  if (!*saveIq)
-  {
-    clear_pending_save_samples_locked();
-    return;
-  }
-
-  std::deque<std::complex<float>> &pending = pendingSaveSamples[channelIndex];
-  for (size_t i = 0; i < nComplexSamples; i++)
-  {
-    pending.push_back({static_cast<float>(samples[2 * i]),
-      static_cast<float>(samples[2 * i + 1])});
-  }
-
-  flush_paired_save_samples_locked();
+  append_blah2_paired_iq_samples(channelIndex, samples, nComplexSamples);
 }
 
 void HackRf::flush_paired_save_samples_locked()

--- a/src/capture/hackrf/HackRf.h
+++ b/src/capture/hackrf/HackRf.h
@@ -11,8 +11,6 @@
 
 #include <complex>
 #include <cstddef>
-#include <deque>
-#include <mutex>
 #include <stdint.h>
 #include <string>
 #include <vector>
@@ -46,12 +44,6 @@ private:
   /// @brief Context data passed into each HackRF callback.
   CallbackContext callbackContexts[2];
 
-  /// @brief Pending channel-aligned save samples waiting to be paired.
-  std::deque<std::complex<float>> pendingSaveSamples[2];
-
-  /// @brief Protects access to pending paired save samples.
-  std::mutex pendingSaveMutex;
-
   /// @brief Check status of HackRF API returns.
   /// @param status Return code of API call.
   /// @param message Message if API call error.
@@ -63,14 +55,6 @@ private:
   /// @param nComplexSamples Number of IQ samples in this callback.
   void append_save_samples(size_t channelIndex, const int8_t *samples,
     size_t nComplexSamples);
-
-  /// @brief Flush paired callback samples into the canonical Blah2 IQ file.
-  /// @return Void.
-  void flush_paired_save_samples_locked();
-
-  /// @brief Clear any unpaired callback save samples.
-  /// @return Void.
-  void clear_pending_save_samples_locked();
 
 protected:
   /// @brief Array of pointers to HackRF devices.

--- a/src/capture/hackrf/HackRf.h
+++ b/src/capture/hackrf/HackRf.h
@@ -3,14 +3,16 @@
 /// @brief A class to capture data on the HackRF.
 /// @author sdn-ninja
 /// @author 30hours
-/// @todo Replay functionality.
-
 #ifndef HACKRF_H
 #define HACKRF_H
 
 #include "capture/Source.h"
 #include "data/IqData.h"
 
+#include <complex>
+#include <cstddef>
+#include <deque>
+#include <mutex>
 #include <stdint.h>
 #include <string>
 #include <vector>
@@ -33,10 +35,42 @@ private:
   /// @brief Enable extra amplifier U13 on receive.
   std::vector<bool> ampEnable;
 
+  /// @brief Callback context for each HackRF receive stream.
+  struct CallbackContext
+  {
+    HackRf *device;
+    IqData *buffer;
+    size_t channelIndex;
+  };
+
+  /// @brief Context data passed into each HackRF callback.
+  CallbackContext callbackContexts[2];
+
+  /// @brief Pending channel-aligned save samples waiting to be paired.
+  std::deque<std::complex<float>> pendingSaveSamples[2];
+
+  /// @brief Protects access to pending paired save samples.
+  std::mutex pendingSaveMutex;
+
   /// @brief Check status of HackRF API returns.
   /// @param status Return code of API call.
   /// @param message Message if API call error.
   void check_status(uint8_t status, std::string message);
+
+  /// @brief Append callback samples into the paired IQ save queues.
+  /// @param channelIndex Zero-based channel index.
+  /// @param samples Pointer to interleaved IQ byte samples.
+  /// @param nComplexSamples Number of IQ samples in this callback.
+  void append_save_samples(size_t channelIndex, const int8_t *samples,
+    size_t nComplexSamples);
+
+  /// @brief Flush paired callback samples into the canonical Blah2 IQ file.
+  /// @return Void.
+  void flush_paired_save_samples_locked();
+
+  /// @brief Clear any unpaired callback save samples.
+  /// @return Void.
+  void clear_pending_save_samples_locked();
 
 protected:
   /// @brief Array of pointers to HackRF devices.

--- a/src/capture/hackrf/HackRf.h
+++ b/src/capture/hackrf/HackRf.h
@@ -11,6 +11,8 @@
 
 #include <complex>
 #include <cstddef>
+#include <deque>
+#include <mutex>
 #include <stdint.h>
 #include <string>
 #include <vector>
@@ -44,6 +46,12 @@ private:
   /// @brief Context data passed into each HackRF callback.
   CallbackContext callbackContexts[2];
 
+  /// @brief Pending channel-aligned save samples waiting to be paired.
+  std::deque<std::complex<float>> pendingSaveSamples[2];
+
+  /// @brief Protects access to pending paired save samples.
+  std::mutex pendingSaveMutex;
+
   /// @brief Check status of HackRF API returns.
   /// @param status Return code of API call.
   /// @param message Message if API call error.
@@ -55,6 +63,14 @@ private:
   /// @param nComplexSamples Number of IQ samples in this callback.
   void append_save_samples(size_t channelIndex, const int8_t *samples,
     size_t nComplexSamples);
+
+  /// @brief Flush paired callback samples into the canonical Blah2 IQ file.
+  /// @return Void.
+  void flush_paired_save_samples_locked();
+
+  /// @brief Clear any unpaired callback save samples.
+  /// @return Void.
+  void clear_pending_save_samples_locked();
 
 protected:
   /// @brief Array of pointers to HackRF devices.

--- a/src/capture/hackrf/HackRf.h
+++ b/src/capture/hackrf/HackRf.h
@@ -72,7 +72,7 @@ public:
   /// @param path Path to save IQ data.
   /// @return The object.
   HackRf(std::string type, uint32_t fc, uint32_t fs, std::string path, 
-    bool *saveIq, std::vector<std::string> serial, 
+    std::atomic<bool> *saveIq, std::vector<std::string> serial, 
     std::vector<uint32_t> gainLna, std::vector<uint32_t> gainVga, 
     std::vector<bool> ampEnable);
 

--- a/src/capture/kraken/Kraken.cpp
+++ b/src/capture/kraken/Kraken.cpp
@@ -124,26 +124,7 @@ void Kraken::callback(unsigned char *buf, uint32_t len, void *ctx)
 void Kraken::append_save_samples(size_t channelIndex, const int8_t *samples,
     size_t nComplexSamples)
 {
-    if (channelIndex > 1 || samples == nullptr)
-    {
-        return;
-    }
-
-    std::lock_guard<std::mutex> lock(pendingSaveMutex);
-    if (!*saveIq)
-    {
-        clear_pending_save_samples_locked();
-        return;
-    }
-
-    std::deque<std::complex<float>> &pending = pendingSaveSamples[channelIndex];
-    for (size_t i = 0; i < nComplexSamples; i++)
-    {
-        pending.push_back({static_cast<float>(samples[2 * i]),
-            static_cast<float>(samples[2 * i + 1])});
-    }
-
-    flush_paired_save_samples_locked();
+    append_blah2_paired_iq_samples(channelIndex, samples, nComplexSamples);
 }
 
 void Kraken::flush_paired_save_samples_locked()

--- a/src/capture/kraken/Kraken.cpp
+++ b/src/capture/kraken/Kraken.cpp
@@ -86,8 +86,14 @@ void Kraken::stop()
 void Kraken::process(IqData *buffer1, IqData *buffer2)
 {
     std::vector<std::thread> threads;
-    threads.emplace_back(rtlsdr_read_async, devs[0], callback, buffer1, 0, 16 * 16384);
-    threads.emplace_back(rtlsdr_read_async, devs[1], callback, buffer2, 0, 16 * 16384);
+    callbackContexts[0].device = this;
+    callbackContexts[0].buffer = buffer1;
+    callbackContexts[0].channelIndex = 0;
+    callbackContexts[1].device = this;
+    callbackContexts[1].buffer = buffer2;
+    callbackContexts[1].channelIndex = 1;
+    threads.emplace_back(rtlsdr_read_async, devs[0], callback, &callbackContexts[0], 0, 16 * 16384);
+    threads.emplace_back(rtlsdr_read_async, devs[1], callback, &callbackContexts[1], 0, 16 * 16384);
     // join threads
     for (auto& thread : threads) {
         thread.join();
@@ -96,8 +102,9 @@ void Kraken::process(IqData *buffer1, IqData *buffer2)
 
 void Kraken::callback(unsigned char *buf, uint32_t len, void *ctx) 
 {
-    IqData* buffer_blah2 = (IqData*)ctx;
-    int8_t* buffer_kraken = (int8_t*)buf;
+    CallbackContext *context = static_cast<CallbackContext *>(ctx);
+    IqData *buffer_blah2 = context->buffer;
+    int8_t *buffer_kraken = reinterpret_cast<int8_t *>(buf);
 
     buffer_blah2->lock();
 
@@ -109,11 +116,71 @@ void Kraken::callback(unsigned char *buf, uint32_t len, void *ctx)
     }
 
     buffer_blah2->unlock_and_notify();
+
+        context->device->append_save_samples(context->channelIndex, buffer_kraken,
+            static_cast<size_t>(len / 2));
+}
+
+void Kraken::append_save_samples(size_t channelIndex, const int8_t *samples,
+    size_t nComplexSamples)
+{
+    if (channelIndex > 1 || samples == nullptr)
+    {
+        return;
+    }
+
+    std::lock_guard<std::mutex> lock(pendingSaveMutex);
+    if (!*saveIq)
+    {
+        clear_pending_save_samples_locked();
+        return;
+    }
+
+    std::deque<std::complex<float>> &pending = pendingSaveSamples[channelIndex];
+    for (size_t i = 0; i < nComplexSamples; i++)
+    {
+        pending.push_back({static_cast<float>(samples[2 * i]),
+            static_cast<float>(samples[2 * i + 1])});
+    }
+
+    flush_paired_save_samples_locked();
+}
+
+void Kraken::flush_paired_save_samples_locked()
+{
+    if (!saveIqFile.is_open())
+    {
+        return;
+    }
+
+    const size_t nPaired = std::min(pendingSaveSamples[0].size(), pendingSaveSamples[1].size());
+    if (nPaired == 0)
+    {
+        return;
+    }
+
+    std::vector<std::complex<float>> reference(nPaired);
+    std::vector<std::complex<float>> surveillance(nPaired);
+    for (size_t i = 0; i < nPaired; i++)
+    {
+        reference[i] = pendingSaveSamples[0].front();
+        pendingSaveSamples[0].pop_front();
+        surveillance[i] = pendingSaveSamples[1].front();
+        pendingSaveSamples[1].pop_front();
+    }
+
+    write_blah2_iq_samples(reference.data(), surveillance.data(), nPaired);
+}
+
+void Kraken::clear_pending_save_samples_locked()
+{
+    pendingSaveSamples[0].clear();
+    pendingSaveSamples[1].clear();
 }
 
 void Kraken::replay(IqData *buffer1, IqData *buffer2, std::string _file, bool _loop)
 {
-    // todo
+    replay_blah2_iq_file(buffer1, buffer2, _file, _loop);
 }
 
 void Kraken::check_status(int status, std::string message)

--- a/src/capture/kraken/Kraken.cpp
+++ b/src/capture/kraken/Kraken.cpp
@@ -7,7 +7,7 @@
 
 // constructor
 Kraken::Kraken(std::string _type, uint32_t _fc, uint32_t _fs, 
-  std::string _path, bool *_saveIq, std::vector<double> _gain)
+    std::string _path, std::atomic<bool> *_saveIq, std::vector<double> _gain)
     : Source(_type, _fc, _fs, _path, _saveIq)
 {
     // convert gain to tenths of dB

--- a/src/capture/kraken/Kraken.cpp
+++ b/src/capture/kraken/Kraken.cpp
@@ -127,38 +127,6 @@ void Kraken::append_save_samples(size_t channelIndex, const int8_t *samples,
     append_blah2_paired_iq_samples(channelIndex, samples, nComplexSamples);
 }
 
-void Kraken::flush_paired_save_samples_locked()
-{
-    if (!saveIqFile.is_open())
-    {
-        return;
-    }
-
-    const size_t nPaired = std::min(pendingSaveSamples[0].size(), pendingSaveSamples[1].size());
-    if (nPaired == 0)
-    {
-        return;
-    }
-
-    std::vector<std::complex<float>> reference(nPaired);
-    std::vector<std::complex<float>> surveillance(nPaired);
-    for (size_t i = 0; i < nPaired; i++)
-    {
-        reference[i] = pendingSaveSamples[0].front();
-        pendingSaveSamples[0].pop_front();
-        surveillance[i] = pendingSaveSamples[1].front();
-        pendingSaveSamples[1].pop_front();
-    }
-
-    write_blah2_iq_samples(reference.data(), surveillance.data(), nPaired);
-}
-
-void Kraken::clear_pending_save_samples_locked()
-{
-    pendingSaveSamples[0].clear();
-    pendingSaveSamples[1].clear();
-}
-
 void Kraken::replay(IqData *buffer1, IqData *buffer2, std::string _file, bool _loop)
 {
     replay_blah2_iq_file(buffer1, buffer2, _file, _loop);

--- a/src/capture/kraken/Kraken.h
+++ b/src/capture/kraken/Kraken.h
@@ -12,14 +12,16 @@
 /// Also works using 2 RTL-SDRs which have been clock synchronised.
 /// @author 30hours, Michael Brock, sdn-ninja
 /// @todo Add support for multiple surveillance channels.
-/// @todo Replay support.
-
 #ifndef KRAKEN_H
 #define KRAKEN_H
 
 #include "capture/Source.h"
 #include "data/IqData.h"
 
+#include <complex>
+#include <cstddef>
+#include <deque>
+#include <mutex>
 #include <stdint.h>
 #include <string>
 #include <vector>
@@ -38,11 +40,43 @@ private:
   /// @brief Gain for each channel.
   std::vector<int> gain;
 
+  /// @brief Callback context for each Kraken receive stream.
+  struct CallbackContext
+  {
+    Kraken *device;
+    IqData *buffer;
+    size_t channelIndex;
+  };
+
+  /// @brief Context data passed into each Kraken callback.
+  CallbackContext callbackContexts[2];
+
+  /// @brief Pending channel-aligned save samples waiting to be paired.
+  std::deque<std::complex<float>> pendingSaveSamples[2];
+
+  /// @brief Protects access to pending paired save samples.
+  std::mutex pendingSaveMutex;
+
   /// @brief Check status of API returns.
   /// @param status Return code of API call.
   /// @param message Message if API call error.
   /// @return Void.
   void check_status(int status, std::string message);
+
+  /// @brief Append callback samples into the paired IQ save queues.
+  /// @param channelIndex Zero-based channel index.
+  /// @param samples Pointer to interleaved IQ byte samples.
+  /// @param nComplexSamples Number of IQ samples in this callback.
+  void append_save_samples(size_t channelIndex, const int8_t *samples,
+    size_t nComplexSamples);
+
+  /// @brief Flush paired callback samples into the canonical Blah2 IQ file.
+  /// @return Void.
+  void flush_paired_save_samples_locked();
+
+  /// @brief Clear any unpaired callback save samples.
+  /// @return Void.
+  void clear_pending_save_samples_locked();
 
   /// @brief Callback function when buffer is filled.
   /// @param buf Pointer to buffer of IQ data.

--- a/src/capture/kraken/Kraken.h
+++ b/src/capture/kraken/Kraken.h
@@ -76,7 +76,7 @@ public:
   /// @param path Path to save IQ data.
   /// @return The object.
   Kraken(std::string type, uint32_t fc, uint32_t fs, std::string path, 
-    bool *saveIq, std::vector<double> gain);
+    std::atomic<bool> *saveIq, std::vector<double> gain);
 
   /// @brief Implement capture function on KrakenSDR.
   /// @param buffer Pointers to buffers for each channel.

--- a/src/capture/kraken/Kraken.h
+++ b/src/capture/kraken/Kraken.h
@@ -20,8 +20,6 @@
 
 #include <complex>
 #include <cstddef>
-#include <deque>
-#include <mutex>
 #include <stdint.h>
 #include <string>
 #include <vector>
@@ -51,12 +49,6 @@ private:
   /// @brief Context data passed into each Kraken callback.
   CallbackContext callbackContexts[2];
 
-  /// @brief Pending channel-aligned save samples waiting to be paired.
-  std::deque<std::complex<float>> pendingSaveSamples[2];
-
-  /// @brief Protects access to pending paired save samples.
-  std::mutex pendingSaveMutex;
-
   /// @brief Check status of API returns.
   /// @param status Return code of API call.
   /// @param message Message if API call error.
@@ -69,14 +61,6 @@ private:
   /// @param nComplexSamples Number of IQ samples in this callback.
   void append_save_samples(size_t channelIndex, const int8_t *samples,
     size_t nComplexSamples);
-
-  /// @brief Flush paired callback samples into the canonical Blah2 IQ file.
-  /// @return Void.
-  void flush_paired_save_samples_locked();
-
-  /// @brief Clear any unpaired callback save samples.
-  /// @return Void.
-  void clear_pending_save_samples_locked();
 
   /// @brief Callback function when buffer is filled.
   /// @param buf Pointer to buffer of IQ data.

--- a/src/capture/rspduo/RspDuo.cpp
+++ b/src/capture/rspduo/RspDuo.cpp
@@ -36,14 +36,14 @@ short max_a_nr = 0;
 short max_b_nr = 0;
 bool run_fg = true;
 bool stats_fg = true;
-bool *capture_fg;
+std::atomic<bool> *capture_fg;
 std::ofstream* saveIqFileLocal;
 IqData *buffer1;
 IqData *buffer2;
 
 // constructor
 RspDuo::RspDuo(std::string _type, uint32_t _fc, 
-  uint32_t _fs, std::string _path, bool *_saveIq,
+  uint32_t _fs, std::string _path, std::atomic<bool> *_saveIq,
   int _agcSetPoint, int _bandwidthNumber, 
   int _gainReductionA, int _gainReductionB, 
   int _lnaState,
@@ -494,7 +494,7 @@ unsigned int reset, void *cbContext)
   buffer2->unlock_and_notify();
 
   // write data to file
-  if (*capture_fg)
+  if (capture_fg != nullptr && capture_fg->load())
   {
     saveIqFileLocal->write(reinterpret_cast<char*>(buffer_16_ar), 
       sizeof(short) * numSamples * 4);

--- a/src/capture/rspduo/RspDuo.cpp
+++ b/src/capture/rspduo/RspDuo.cpp
@@ -149,33 +149,7 @@ void RspDuo::process(IqData *_buffer1, IqData *_buffer2)
 
 void RspDuo::replay(IqData *_buffer1, IqData *_buffer2, std::string _file, bool _loop)
 {
-  buffer1 = _buffer1;
-  buffer2 = _buffer2;
-
-  short i1, q1, i2, q2;
-  int rv;
-  file_replay = fopen(_file.c_str(), "rb");
-
-  while (true)
-  {
-    rv = fread(&i1, 1, sizeof(short), file_replay);
-    if (rv != sizeof(short)) break; 
-    rv = fread(&q1, 1, sizeof(short), file_replay);
-    if (rv != sizeof(short)) break; 
-    rv = fread(&i2, 1, sizeof(short), file_replay);
-    if (rv != sizeof(short)) break; 
-    rv = fread(&q2, 1, sizeof(short), file_replay);
-    if (rv != sizeof(short)) break; 
-    buffer1->lock();
-    buffer2->lock();
-    if (buffer1->get_length() < buffer1->get_n())
-    {
-      buffer1->push_back({(double)i1, (double)q1});
-      buffer2->push_back({(double)i2, (double)q2});
-    }
-    buffer1->unlock_and_notify();
-    buffer2->unlock_and_notify();
-  }
+  replay_blah2_iq_file(_buffer1, _buffer2, _file, _loop);
 }
 
 void RspDuo::validate() {

--- a/src/capture/rspduo/RspDuo.h
+++ b/src/capture/rspduo/RspDuo.h
@@ -183,7 +183,7 @@ public:
   /// @return Void.
   void stop();
 
-  /// @brief Implement replay function on RSPduo.
+  /// @brief Replay a Blah2 two-channel IQ file.
   /// @param buffer1 Pointer to reference buffer.
   /// @param buffer2 Pointer to surveillance buffer.
   /// @param file Path to file to replay data from.

--- a/src/capture/rspduo/RspDuo.h
+++ b/src/capture/rspduo/RspDuo.h
@@ -161,7 +161,7 @@ public:
   /// @param path Path to save IQ data.
   /// @return The object.
   RspDuo(std::string type, uint32_t fc, uint32_t fs, 
-    std::string path, bool *saveIq, int agcSetPoint, 
+    std::string path, std::atomic<bool> *saveIq, int agcSetPoint, 
     int bandwidthNumber, int gainReductionA, int gainReductionB, 
     int lnaState, bool dabNotch, bool rfNotch);
 

--- a/src/capture/usrp/Usrp.cpp
+++ b/src/capture/usrp/Usrp.cpp
@@ -2,14 +2,15 @@
 
 #include <string.h>
 #include <iostream>
+#include <limits>
 #include <vector>
 #include <complex>
 #include <uhd/usrp/multi_usrp.hpp>
 
 // constructor
-Usrp::Usrp(std::string _type, uint32_t _fc, uint32_t _fs, 
-  std::string _path, bool *_saveIq, std::string _address, 
-  std::string _subdev, std::vector<std::string> _antenna, 
+Usrp::Usrp(std::string _type, uint32_t _fc, uint32_t _fs,
+  std::string _path, bool *_saveIq, std::string _address,
+  std::string _subdev, std::vector<std::string> _antenna,
   std::vector<double> _gain)
     : Source(_type, _fc, _fs, _path, _saveIq)
 {
@@ -30,7 +31,7 @@ void Usrp::stop()
 void Usrp::process(IqData *buffer1, IqData *buffer2)
 {
     // create a USRP object
-    uhd::usrp::multi_usrp::sptr usrp = 
+    uhd::usrp::multi_usrp::sptr usrp =
       uhd::usrp::multi_usrp::make(address);
 
     usrp->set_rx_subdev_spec(uhd::usrp::subdev_spec_t(subdev), 0);
@@ -95,7 +96,8 @@ void Usrp::process(IqData *buffer1, IqData *buffer2)
       // save IQ data to file
       if (*saveIq)
       {
-        write_blah2_iq_samples(buff_ptrs[0], buff_ptrs[1], nReceived);
+        constexpr double kUsrpIqScale = static_cast<double>(std::numeric_limits<int16_t>::max());
+        write_blah2_iq_samples(buff_ptrs[0], buff_ptrs[1], nReceived, kUsrpIqScale);
       }
     }
 }

--- a/src/capture/usrp/Usrp.cpp
+++ b/src/capture/usrp/Usrp.cpp
@@ -95,17 +95,12 @@ void Usrp::process(IqData *buffer1, IqData *buffer2)
       // save IQ data to file
       if (*saveIq)
       {
-        for (const auto& bufferPtr : buff_ptrs) 
-        {
-        // Write the buffer data to the file
-          saveIqFile.write(reinterpret_cast<const char*>(
-            bufferPtr), samps_per_buff * sizeof(std::complex<float>));
-        }
+        write_blah2_iq_samples(buff_ptrs[0], buff_ptrs[1], nReceived);
       }
     }
 }
 
 void Usrp::replay(IqData *buffer1, IqData *buffer2, std::string _file, bool _loop)
 {
-  return;
+  replay_blah2_iq_file(buffer1, buffer2, _file, _loop);
 }

--- a/src/capture/usrp/Usrp.cpp
+++ b/src/capture/usrp/Usrp.cpp
@@ -9,7 +9,7 @@
 
 // constructor
 Usrp::Usrp(std::string _type, uint32_t _fc, uint32_t _fs,
-  std::string _path, bool *_saveIq, std::string _address,
+  std::string _path, std::atomic<bool> *_saveIq, std::string _address,
   std::string _subdev, std::vector<std::string> _antenna,
   std::vector<double> _gain)
     : Source(_type, _fc, _fs, _path, _saveIq)
@@ -94,7 +94,7 @@ void Usrp::process(IqData *buffer1, IqData *buffer2)
       buffer2->unlock_and_notify();
 
       // save IQ data to file
-      if (*saveIq)
+      if (saveIq != nullptr && saveIq->load())
       {
         constexpr double kUsrpIqScale = static_cast<double>(std::numeric_limits<int16_t>::max());
         write_blah2_iq_samples(buff_ptrs[0], buff_ptrs[1], nReceived, kUsrpIqScale);

--- a/src/capture/usrp/Usrp.h
+++ b/src/capture/usrp/Usrp.h
@@ -8,7 +8,6 @@
 /// Requires a USB 3.0 cable for higher data rates.
 ///
 /// @author 30hours
-/// @todo Add replay to Usrp.
 /// @todo Fix single overflow per CPI.
 /// @todo Fix occasional timeout ERROR_CODE_TIMEOUT.
 
@@ -63,7 +62,7 @@ public:
   /// @return Void.
   void stop();
 
-  /// @brief Implement replay function on RSPduo.
+  /// @brief Replay a Blah2 two-channel IQ file.
   /// @param buffer1 Pointer to reference buffer.
   /// @param buffer2 Pointer to surveillance buffer.
   /// @param file Path to file to replay data from.

--- a/src/capture/usrp/Usrp.h
+++ b/src/capture/usrp/Usrp.h
@@ -45,7 +45,7 @@ public:
   /// @param path Path to save IQ data.
   /// @return The object.
   Usrp(std::string type, uint32_t fc, uint32_t fs, std::string path, 
-    bool *saveIq, std::string address, std::string subdev, 
+    std::atomic<bool> *saveIq, std::string address, std::string subdev, 
     std::vector<std::string> antenna, std::vector<double> gain);
 
   /// @brief Implement capture function on USRP.

--- a/src/data/IqData.cpp
+++ b/src/data/IqData.cpp
@@ -54,6 +54,17 @@ void IqData::wait_for_min_length(uint32_t minLength)
   data_ready.wait(lock, [&] { return length >= minLength; });
 }
 
+void IqData::wait_for_max_length(uint32_t maxLength)
+{
+  if (maxLength > n)
+  {
+    throw std::invalid_argument("IqData::wait_for_max_length maxLength exceeds buffer capacity");
+  }
+
+  std::unique_lock<std::mutex> lock(mutex_lock);
+  data_ready.wait(lock, [&] { return length <= maxLength; });
+}
+
 std::deque<std::complex<double>> IqData::get_data()
 {
   std::deque<std::complex<double>> out;

--- a/src/data/IqData.h
+++ b/src/data/IqData.h
@@ -81,6 +81,11 @@ public:
   /// @return Void.
   void wait_for_min_length(uint32_t minLength);
 
+  /// @brief Wait until the buffer length is at most maxLength.
+  /// @param maxLength Maximum allowed samples in buffer.
+  /// @return Void.
+  void wait_for_max_length(uint32_t maxLength);
+
   /// @brief Getter for data.
   /// @return IQ data.
   std::deque<std::complex<double>> get_data();

--- a/test/README.md
+++ b/test/README.md
@@ -89,6 +89,30 @@ sudo docker exec -it blah2 /blah2/bin/test/comparison/testDetectionSweep \
 
 With `--adsb-file`, the sweep summary adds truth-aware columns for matched Blah2 detection points, false-positive detection points, missed ADS-B truth points, and the corresponding per-detection-point rates for each sweep case.
 
+### Interpreting the sweep summary
+
+When `--adsb-file` is supplied, `testDetectionSweep` scores each Blah2 detection point independently against at most one ADS-B truth point from the nearest snapshot within `--adsb-max-age-ms`. This score is per detection point, not per CPI and not per aircraft track.
+
+- `Rank`: Sort order of the sweep cases. With ADS-B truth, cases are ranked by higher `MatchPctPt`, then lower `FPRatePt`, then higher `MatchPts`. Without ADS-B truth, ranking falls back to `HitRate`, `MeanPeakSnr`, and `Mean/CPI`.
+- `Mode`: CFAR mode used for that sweep case.
+- `Pfa`: CFAR probability of false alarm used for that sweep case. The table prints 3 decimal places, so values such as `1e-5` and `1e-4` will appear as `0.000`.
+- `MinDoppHz`: Minimum Doppler threshold in Hz.
+- `MinDelay`: Minimum delay-bin threshold applied by the detector.
+- `HitRate`: Fraction of analysed CPIs that produced at least one detection. This is not truth accuracy.
+- `TotalDetect`: Total number of detection points produced across all analysed CPIs.
+- `Mean/CPI`: Average number of detection points per analysed CPI.
+- `MeanPeakSnr`: Average peak SNR among CPIs that produced at least one detection.
+- `TruthCPI`: Number of analysed CPIs that had a nearby ADS-B snapshot within the configured max-age window. A single ADS-B snapshot can be reused by more than one CPI if it is the nearest valid snapshot.
+- `MatchPts`: Number of Blah2 detection points that matched an ADS-B truth point inside the configured delay and Doppler windows.
+- `FalsePts`: Number of Blah2 detection points that did not match any ADS-B truth point.
+- `MissedPts`: Number of ADS-B truth points that were not matched by any Blah2 detection point.
+- `MatchPctPt`: `MatchPts / (MatchPts + FalsePts)`. This is effectively point-level precision.
+- `FPRatePt`: `FalsePts / (MatchPts + FalsePts)`, which is equal to `1 - MatchPctPt`.
+
+`testDetectionSweep` does not currently print recall directly. If needed, estimate truth-side recall for a sweep case as `MatchPts / (MatchPts + MissedPts)`.
+
+In practice, a high `HitRate` with a very low `MatchPctPt` means the detector is firing often, but most of those detections do not align with ADS-B truth under the current match windows.
+
 If you already have a saved IQ file, you can run the same comparison command directly against that file.
 
 - *TODO:* Run all test cases.

--- a/test/README.md
+++ b/test/README.md
@@ -36,6 +36,48 @@ sudo docker exec -it blah2 /blah2/bin/test/functional/testFunctional
 sudo docker exec -it blah2 /blah2/bin/test/comparison/testComparison
 ```
 
+- Capture a Blah2 IQ file during a normal live run, then replay it in the detector sweep comparison.
+
+1. Configure blah2 for a normal live run, not replay mode, and point saves at a writable directory.
+
+```yml
+capture:
+  replay:
+    state: false
+
+save:
+  path: "/blah2/save/"
+```
+
+2. Start `blah2` and the API server normally with that config.
+
+3. Capture the scene you want while the live system is running. Start recording, wait until enough data has been collected, then stop recording.
+
+Use either the IQ Capture button on one of the three detection map pages, or the API toggle endpoint.
+
+```
+curl http://127.0.0.1:3000/capture/toggle
+curl http://127.0.0.1:3000/capture/toggle
+```
+
+blah2 writes a canonical two-channel interleaved IQ file under `save.path` with a timestamped name such as `/blah2/save/20260425-153000.rspduo.iq` or `/blah2/save/20260425-153000.hackrf.iq`.
+
+4. Replay that captured file in the detector sweep comparison.
+
+Do not change `capture.replay.state` to `true` for this step. That setting is used by the main `blah2` runtime when you want the full application to replay data instead of reading live hardware. `testDetectionSweep` only needs the replay file path, either from `--replay-file` or from `capture.replay.file` in the config.
+
+```
+sudo docker exec -it blah2 /blah2/bin/test/comparison/testDetectionSweep \
+	--config /blah2/config/config.yml \
+	--replay-file /blah2/save/20260425-153000.rspduo.iq \
+	--pfa 1e-5,1e-4,1e-3 \
+	--min-doppler 5,10,15 \
+	--min-delay 0,5,10 \
+	--cfar-modes CAGO
+```
+
+If you already have a saved IQ file, you can run the same comparison command directly against that file.
+
 - *TODO:* Run all test cases.
 
 ```

--- a/test/README.md
+++ b/test/README.md
@@ -45,6 +45,10 @@ capture:
   replay:
     state: false
 
+truth:
+  adsb:
+    enabled: true
+
 save:
   path: "/blah2/save/"
 ```
@@ -62,19 +66,28 @@ curl http://127.0.0.1:3000/capture/toggle
 
 blah2 writes a canonical two-channel interleaved IQ file under `save.path` with a timestamped name such as `/blah2/save/20260425-153000.rspduo.iq` or `/blah2/save/20260425-153000.hackrf.iq`.
 
+If `truth.adsb.enabled` is true, blah2 writes a matching ADS-B sidecar for each IQ capture file, for example `/blah2/save/20260425-153000.rspduo.adsb` or `/blah2/save/20260425-153000.hackrf.adsb`, but only while the Start IQ Capture toggle is active. Each entry stores a CPI timestamp and the ADS-B delay-Doppler targets seen during that capture window.
+
 4. Replay that captured file in the detector sweep comparison.
 
 Do not change `capture.replay.state` to `true` for this step. That setting is used by the main `blah2` runtime when you want the full application to replay data instead of reading live hardware. `testDetectionSweep` only needs the replay file path, either from `--replay-file` or from `capture.replay.file` in the config.
+
+If you want to score replay detections against ADS-B truth, pass the saved `.adsb` sidecar as well. The comparison uses the replay capture start time inferred from the IQ file name, unless you override it with `--capture-start-ms`.
 
 ```
 sudo docker exec -it blah2 /blah2/bin/test/comparison/testDetectionSweep \
 	--config /blah2/config/config.yml \
 	--replay-file /blah2/save/20260425-153000.rspduo.iq \
+	--adsb-file /blah2/save/20260425-153000.rspduo.adsb \
 	--pfa 1e-5,1e-4,1e-3 \
 	--min-doppler 5,10,15 \
 	--min-delay 0,5,10 \
-	--cfar-modes CAGO
+	--cfar-modes CAGO \
+	--adsb-delay-window-km 1.0 \
+	--adsb-doppler-window-hz 10
 ```
+
+With `--adsb-file`, the sweep summary adds truth-aware columns for matched Blah2 detections, false positives, missed ADS-B targets, and the match / false-positive rates for each sweep case.
 
 If you already have a saved IQ file, you can run the same comparison command directly against that file.
 

--- a/test/README.md
+++ b/test/README.md
@@ -66,13 +66,13 @@ curl http://127.0.0.1:3000/capture/toggle
 
 blah2 writes a canonical two-channel interleaved IQ file under `save.path` with a timestamped name such as `/blah2/save/20260425-153000.rspduo.iq` or `/blah2/save/20260425-153000.hackrf.iq`.
 
-If `truth.adsb.enabled` is true, blah2 writes a matching ADS-B sidecar for each IQ capture file, for example `/blah2/save/20260425-153000.rspduo.adsb` or `/blah2/save/20260425-153000.hackrf.adsb`, but only while the Start IQ Capture toggle is active. Each entry stores a CPI timestamp and the ADS-B delay-Doppler targets seen during that capture window.
+If `truth.adsb.enabled` is true, blah2 writes a matching ADS-B sidecar for each IQ capture file, for example `/blah2/save/20260425-153000.rspduo.adsb` or `/blah2/save/20260425-153000.hackrf.adsb`, but only while the Start IQ Capture toggle is active. The sidecar stores the explicit capture start time once plus the CPI timestamped ADS-B delay-Doppler targets seen during that capture window.
 
 4. Replay that captured file in the detector sweep comparison.
 
 Do not change `capture.replay.state` to `true` for this step. That setting is used by the main `blah2` runtime when you want the full application to replay data instead of reading live hardware. `testDetectionSweep` only needs the replay file path, either from `--replay-file` or from `capture.replay.file` in the config.
 
-If you want to score replay detections against ADS-B truth, pass the saved `.adsb` sidecar as well. The comparison uses the replay capture start time inferred from the IQ file name, unless you override it with `--capture-start-ms`.
+If you want to score replay detections against ADS-B truth, pass the saved `.adsb` sidecar as well. `testDetectionSweep` prefers the explicit capture start time stored inside new sidecars, and only falls back to `--capture-start-ms` or IQ file-name inference for older sidecars.
 
 ```
 sudo docker exec -it blah2 /blah2/bin/test/comparison/testDetectionSweep \
@@ -87,7 +87,7 @@ sudo docker exec -it blah2 /blah2/bin/test/comparison/testDetectionSweep \
 	--adsb-doppler-window-hz 10
 ```
 
-With `--adsb-file`, the sweep summary adds truth-aware columns for matched Blah2 detections, false positives, missed ADS-B targets, and the match / false-positive rates for each sweep case.
+With `--adsb-file`, the sweep summary adds truth-aware columns for matched Blah2 detection points, false-positive detection points, missed ADS-B truth points, and the corresponding per-detection-point rates for each sweep case.
 
 If you already have a saved IQ file, you can run the same comparison command directly against that file.
 

--- a/test/comparison/TestDetectionSweep.cpp
+++ b/test/comparison/TestDetectionSweep.cpp
@@ -487,28 +487,54 @@ uint64_t absolute_diff_u64(uint64_t left, uint64_t right)
   return (left > right) ? (left - right) : (right - left);
 }
 
+double parse_adsb_numeric_value(const rapidjson::Value &value, const std::string &fieldName)
+{
+  if (value.IsNumber())
+  {
+    return value.GetDouble();
+  }
+
+  if (!value.IsString())
+  {
+    throw std::runtime_error("ADS-B target field '" + fieldName + "' must be numeric or a numeric string");
+  }
+
+  try
+  {
+    size_t parsedLength = 0;
+    const std::string text = value.GetString();
+    const double parsedValue = std::stod(text, &parsedLength);
+    if (parsedLength != text.size())
+    {
+      throw std::runtime_error("ADS-B target field '" + fieldName + "' contains trailing characters");
+    }
+    return parsedValue;
+  }
+  catch (const std::exception &)
+  {
+    throw std::runtime_error("ADS-B target field '" + fieldName + "' must be a parseable number");
+  }
+}
+
 std::vector<double> parse_adsb_axis_values(const rapidjson::Value &value, const std::string &fieldName)
 {
   std::vector<double> values;
-  if (value.IsNumber())
+  if (value.IsNumber() || value.IsString())
   {
-    values.push_back(value.GetDouble());
+    values.push_back(parse_adsb_numeric_value(value, fieldName));
     return values;
   }
 
   if (!value.IsArray())
   {
-    throw std::runtime_error("ADS-B target field '" + fieldName + "' must be a number or array of numbers");
+    throw std::runtime_error(
+      "ADS-B target field '" + fieldName + "' must be a number, numeric string, or array of those values");
   }
 
   values.reserve(value.Size());
   for (const rapidjson::Value &entry : value.GetArray())
   {
-    if (!entry.IsNumber())
-    {
-      throw std::runtime_error("ADS-B target field '" + fieldName + "' contains a non-numeric value");
-    }
-    values.push_back(entry.GetDouble());
+    values.push_back(parse_adsb_numeric_value(entry, fieldName));
   }
   return values;
 }

--- a/test/comparison/TestDetectionSweep.cpp
+++ b/test/comparison/TestDetectionSweep.cpp
@@ -1,0 +1,647 @@
+/// @file TestDetectionSweep.cpp
+/// @brief Sweep detection parameters over replay IQ data and print ranked summaries.
+/// @author 30hours
+
+#include "data/IqData.h"
+#include "data/Map.h"
+#include "data/Detection.h"
+#include "process/ambiguity/Ambiguity.h"
+#include "process/clutter/WienerHopf.h"
+#include "process/detection/Centroid.h"
+#include "process/detection/CfarDetector1D.h"
+#include "process/detection/Interpolate.h"
+
+#include <ryml/ryml.hpp>
+#include <ryml/ryml_std.hpp>
+
+#include <algorithm>
+#include <cmath>
+#include <cctype>
+#include <cstdint>
+#include <fstream>
+#include <iomanip>
+#include <iostream>
+#include <limits>
+#include <memory>
+#include <numeric>
+#include <sstream>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+namespace
+{
+struct CliOptions
+{
+  std::string configPath;
+  std::string replayFile;
+  std::vector<double> pfas;
+  std::vector<double> minDopplers;
+  std::vector<int> minDelays;
+  std::vector<CfarMode> modes;
+  uint64_t maxCpis = 0;
+};
+
+struct RuntimeConfig
+{
+  std::string replayFile;
+  uint32_t fs = 0;
+  double tCpi = 0.0;
+  uint32_t nSamples = 0;
+  int32_t ambiguityDelayMin = 0;
+  int32_t ambiguityDelayMax = 0;
+  int32_t ambiguityDopplerMin = 0;
+  int32_t ambiguityDopplerMax = 0;
+  bool clutterEnable = false;
+  int32_t clutterDelayMin = 0;
+  int32_t clutterDelayMax = 0;
+  int32_t nGuard = 0;
+  int32_t nTrain = 0;
+  int32_t minDelay = 0;
+  double pfa = 0.0;
+  double minDoppler = 0.0;
+  CfarMode cfarMode = CfarMode::CAGO;
+  uint16_t nCentroid = 0;
+};
+
+struct SweepCase
+{
+  double pfa;
+  double minDoppler;
+  int minDelay;
+  CfarMode mode;
+  CfarDetector1D detector;
+  uint64_t cpisProcessed = 0;
+  uint64_t cpisWithDetections = 0;
+  uint64_t totalDetections = 0;
+  double peakSnrSum = 0.0;
+
+  SweepCase(double _pfa, int8_t nGuard, int8_t nTrain, int _minDelay,
+    double _minDoppler, CfarMode _mode)
+    : pfa(_pfa),
+      minDoppler(_minDoppler),
+      minDelay(_minDelay),
+      mode(_mode),
+      detector(_pfa, nGuard, nTrain, static_cast<int8_t>(_minDelay), _minDoppler, _mode)
+  {
+  }
+
+  void record(const Detection &detection)
+  {
+    cpisProcessed++;
+    const std::vector<double> &snr = detection.get_snr();
+    totalDetections += detection.get_nDetections();
+
+    if (!snr.empty())
+    {
+      cpisWithDetections++;
+      peakSnrSum += *std::max_element(snr.begin(), snr.end());
+    }
+  }
+
+  double detection_rate() const
+  {
+    if (cpisProcessed == 0)
+    {
+      return 0.0;
+    }
+    return static_cast<double>(cpisWithDetections) / static_cast<double>(cpisProcessed);
+  }
+
+  double mean_detections() const
+  {
+    if (cpisProcessed == 0)
+    {
+      return 0.0;
+    }
+    return static_cast<double>(totalDetections) / static_cast<double>(cpisProcessed);
+  }
+
+  double mean_peak_snr() const
+  {
+    if (cpisWithDetections == 0)
+    {
+      return std::numeric_limits<double>::quiet_NaN();
+    }
+    return peakSnrSum / static_cast<double>(cpisWithDetections);
+  }
+};
+
+std::string trim(const std::string &value)
+{
+  const size_t first = value.find_first_not_of(" \t\n\r");
+  if (first == std::string::npos)
+  {
+    return "";
+  }
+  const size_t last = value.find_last_not_of(" \t\n\r");
+  return value.substr(first, last - first + 1);
+}
+
+std::string to_upper(std::string value)
+{
+  std::transform(value.begin(), value.end(), value.begin(),
+    [](unsigned char character) {
+      return static_cast<char>(std::toupper(character));
+    });
+  return value;
+}
+
+template <typename T, typename Parser>
+std::vector<T> parse_csv_list(const std::string &csv, Parser parser)
+{
+  std::vector<T> values;
+  std::stringstream stream(csv);
+  std::string token;
+  while (std::getline(stream, token, ','))
+  {
+    token = trim(token);
+    if (token.empty())
+    {
+      continue;
+    }
+    values.push_back(parser(token));
+  }
+  return values;
+}
+
+template <typename T>
+void dedupe_preserve_order(std::vector<T> &values)
+{
+  std::vector<T> deduped;
+  for (const T &value : values)
+  {
+    if (std::find(deduped.begin(), deduped.end(), value) == deduped.end())
+    {
+      deduped.push_back(value);
+    }
+  }
+  values.swap(deduped);
+}
+
+bool try_parse_cfar_mode(const std::string &value, CfarMode &mode)
+{
+  const std::string normalized = to_upper(trim(value));
+  if (normalized == "CA")
+  {
+    mode = CfarMode::CA;
+    return true;
+  }
+  if (normalized == "CAGO")
+  {
+    mode = CfarMode::CAGO;
+    return true;
+  }
+  return false;
+}
+
+std::string format_mode(CfarMode mode)
+{
+  return (mode == CfarMode::CAGO) ? "CAGO" : "CA";
+}
+
+void print_help()
+{
+  std::cout
+    << "Sweep detector parameters against a Blah2 replay IQ file.\n\n"
+    << "Required:\n"
+    << "  --config <file.yml>        Base blah2 config file.\n\n"
+    << "Optional:\n"
+    << "  --replay-file <file.iq>    Override capture.replay.file from config.\n"
+    << "  --pfa <csv>                Comma-separated Pfa values, e.g. 1e-5,1e-4,1e-3.\n"
+    << "  --min-doppler <csv>        Comma-separated minimum Doppler thresholds in Hz.\n"
+    << "  --min-delay <csv>          Comma-separated minimum delay thresholds in bins.\n"
+    << "  --cfar-modes <csv>         Comma-separated modes from CA,CAGO.\n"
+    << "  --max-cpis <n>             Limit replay processing to the first n CPIs.\n"
+    << "  --help                     Show this help text.\n\n"
+    << "Example:\n"
+    << "  testDetectionSweep --config config/config.yml --replay-file /tmp/capture.iq \\\n"
+    << "    --pfa 1e-5,1e-4,1e-3 --min-doppler 5,10,15 --min-delay 0,5,10 --cfar-modes CAGO\n";
+}
+
+bool parse_arguments(int argc, char **argv, CliOptions &options, int &exitCode)
+{
+  exitCode = 0;
+  for (int i = 1; i < argc; i++)
+  {
+    const std::string argument = argv[i];
+    const auto require_value = [&](const std::string &name) -> std::string {
+      if (i + 1 >= argc)
+      {
+        throw std::invalid_argument("Missing value for " + name);
+      }
+      i++;
+      return argv[i];
+    };
+
+    if (argument == "--help")
+    {
+      print_help();
+      exitCode = 0;
+      return false;
+    }
+    if (argument == "--config")
+    {
+      options.configPath = require_value(argument);
+      continue;
+    }
+    if (argument == "--replay-file")
+    {
+      options.replayFile = require_value(argument);
+      continue;
+    }
+    if (argument == "--pfa")
+    {
+      options.pfas = parse_csv_list<double>(require_value(argument), [](const std::string &value) {
+        return std::stod(value);
+      });
+      continue;
+    }
+    if (argument == "--min-doppler")
+    {
+      options.minDopplers = parse_csv_list<double>(require_value(argument), [](const std::string &value) {
+        return std::stod(value);
+      });
+      continue;
+    }
+    if (argument == "--min-delay")
+    {
+      options.minDelays = parse_csv_list<int>(require_value(argument), [](const std::string &value) {
+        return std::stoi(value);
+      });
+      continue;
+    }
+    if (argument == "--cfar-modes")
+    {
+      options.modes = parse_csv_list<CfarMode>(require_value(argument), [](const std::string &value) {
+        CfarMode mode = CfarMode::CA;
+        if (!try_parse_cfar_mode(value, mode))
+        {
+          throw std::invalid_argument("Unsupported CFAR mode '" + value + "'");
+        }
+        return mode;
+      });
+      continue;
+    }
+    if (argument == "--max-cpis")
+    {
+      options.maxCpis = static_cast<uint64_t>(std::stoull(require_value(argument)));
+      continue;
+    }
+
+    throw std::invalid_argument("Unknown argument '" + argument + "'");
+  }
+
+  if (options.configPath.empty())
+  {
+    std::cerr << "Missing required --config argument" << std::endl;
+    print_help();
+    exitCode = 1;
+    return false;
+  }
+
+  dedupe_preserve_order(options.pfas);
+  dedupe_preserve_order(options.minDopplers);
+  dedupe_preserve_order(options.minDelays);
+  dedupe_preserve_order(options.modes);
+  return true;
+}
+
+std::string read_text_file(const std::string &path)
+{
+  std::ifstream file(path);
+  if (!file.is_open())
+  {
+    throw std::runtime_error("Unable to open config file '" + path + "'");
+  }
+
+  std::stringstream buffer;
+  buffer << file.rdbuf();
+  return buffer.str();
+}
+
+void validate_runtime_config(const RuntimeConfig &config)
+{
+  if (config.replayFile.empty())
+  {
+    throw std::runtime_error("No replay file configured. Set capture.replay.file or pass --replay-file");
+  }
+  if (config.fs == 0 || !std::isfinite(config.tCpi) || config.tCpi <= 0.0)
+  {
+    throw std::runtime_error("Invalid capture/process config: fs and CPI must be positive finite values");
+  }
+  if (config.nSamples == 0)
+  {
+    throw std::runtime_error("Derived CPI sample count is zero");
+  }
+  if (config.nGuard < 0 || config.nGuard > std::numeric_limits<int8_t>::max())
+  {
+    throw std::runtime_error("process.detection.nGuard must fit in int8 range");
+  }
+  if (config.nTrain < 0 || config.nTrain > std::numeric_limits<int8_t>::max())
+  {
+    throw std::runtime_error("process.detection.nTrain must fit in int8 range");
+  }
+  if (config.minDelay < std::numeric_limits<int8_t>::min() ||
+    config.minDelay > std::numeric_limits<int8_t>::max())
+  {
+    throw std::runtime_error("process.detection.minDelay must fit in int8 range");
+  }
+  if (!(config.pfa > 0.0 && config.pfa < 1.0))
+  {
+    throw std::runtime_error("process.detection.pfa must be between 0 and 1");
+  }
+}
+
+RuntimeConfig load_runtime_config(const CliOptions &options)
+{
+  RuntimeConfig config;
+
+  std::string contents = read_text_file(options.configPath);
+  ryml::Tree tree = ryml::parse_in_arena(ryml::to_csubstr(contents));
+
+  tree["capture"]["fs"] >> config.fs;
+  tree["capture"]["replay"]["file"] >> config.replayFile;
+  tree["process"]["data"]["cpi"] >> config.tCpi;
+  tree["process"]["ambiguity"]["delayMin"] >> config.ambiguityDelayMin;
+  tree["process"]["ambiguity"]["delayMax"] >> config.ambiguityDelayMax;
+  tree["process"]["ambiguity"]["dopplerMin"] >> config.ambiguityDopplerMin;
+  tree["process"]["ambiguity"]["dopplerMax"] >> config.ambiguityDopplerMax;
+  tree["process"]["clutter"]["enable"] >> config.clutterEnable;
+  tree["process"]["clutter"]["delayMin"] >> config.clutterDelayMin;
+  tree["process"]["clutter"]["delayMax"] >> config.clutterDelayMax;
+  tree["process"]["detection"]["pfa"] >> config.pfa;
+  tree["process"]["detection"]["nGuard"] >> config.nGuard;
+  tree["process"]["detection"]["nTrain"] >> config.nTrain;
+  tree["process"]["detection"]["minDelay"] >> config.minDelay;
+  tree["process"]["detection"]["minDoppler"] >> config.minDoppler;
+  tree["process"]["detection"]["nCentroid"] >> config.nCentroid;
+
+  std::string modeString = "CAGO";
+  auto cfarModeNode = tree["process"]["detection"]["cfarMode"];
+  if (cfarModeNode.valid())
+  {
+    cfarModeNode >> modeString;
+  }
+  if (!try_parse_cfar_mode(modeString, config.cfarMode))
+  {
+    throw std::runtime_error("Unsupported process.detection.cfarMode '" + modeString + "'");
+  }
+
+  if (!options.replayFile.empty())
+  {
+    config.replayFile = options.replayFile;
+  }
+
+  const double samplesPerCpi = static_cast<double>(config.fs) * config.tCpi;
+  if (!std::isfinite(samplesPerCpi) || samplesPerCpi <= 0.0 ||
+    samplesPerCpi > static_cast<double>(std::numeric_limits<uint32_t>::max()))
+  {
+    throw std::runtime_error("Invalid derived CPI sample count");
+  }
+  config.nSamples = static_cast<uint32_t>(samplesPerCpi);
+
+  validate_runtime_config(config);
+  return config;
+}
+
+std::vector<SweepCase> build_sweep_cases(const CliOptions &options, const RuntimeConfig &config)
+{
+  std::vector<double> pfas = options.pfas;
+  std::vector<double> minDopplers = options.minDopplers;
+  std::vector<int> minDelays = options.minDelays;
+  std::vector<CfarMode> modes = options.modes;
+
+  if (pfas.empty())
+  {
+    pfas.push_back(config.pfa);
+  }
+  if (minDopplers.empty())
+  {
+    minDopplers.push_back(config.minDoppler);
+  }
+  if (minDelays.empty())
+  {
+    minDelays.push_back(config.minDelay);
+  }
+  if (modes.empty())
+  {
+    modes.push_back(config.cfarMode);
+  }
+
+  for (double pfa : pfas)
+  {
+    if (!(pfa > 0.0 && pfa < 1.0))
+    {
+      throw std::runtime_error("Sweep pfa values must be between 0 and 1");
+    }
+  }
+  for (int minDelay : minDelays)
+  {
+    if (minDelay < std::numeric_limits<int8_t>::min() ||
+      minDelay > std::numeric_limits<int8_t>::max())
+    {
+      throw std::runtime_error("Sweep minDelay values must fit in int8 range");
+    }
+  }
+
+  std::vector<SweepCase> sweepCases;
+  for (CfarMode mode : modes)
+  {
+    for (double pfa : pfas)
+    {
+      for (double minDoppler : minDopplers)
+      {
+        for (int minDelay : minDelays)
+        {
+          sweepCases.emplace_back(pfa, static_cast<int8_t>(config.nGuard),
+            static_cast<int8_t>(config.nTrain), minDelay, minDoppler, mode);
+        }
+      }
+    }
+  }
+
+  return sweepCases;
+}
+
+bool read_blah2_iq_cpi(std::ifstream &replay, uint32_t nSamples, IqData &x, IqData &y)
+{
+  std::vector<int16_t> raw(static_cast<size_t>(nSamples) * 4, 0);
+  const std::streamsize expectedBytes = static_cast<std::streamsize>(raw.size() * sizeof(int16_t));
+  replay.read(reinterpret_cast<char *>(raw.data()), expectedBytes);
+
+  if (replay.gcount() == 0)
+  {
+    return false;
+  }
+  if (replay.gcount() != expectedBytes)
+  {
+    std::cerr << "Ignoring trailing partial CPI at end of replay file" << std::endl;
+    return false;
+  }
+
+  x.clear();
+  y.clear();
+  for (size_t index = 0; index < raw.size(); index += 4)
+  {
+    x.push_back({static_cast<double>(raw[index]), static_cast<double>(raw[index + 1])});
+    y.push_back({static_cast<double>(raw[index + 2]), static_cast<double>(raw[index + 3])});
+  }
+  return true;
+}
+
+std::string format_metric(double value)
+{
+  if (std::isnan(value))
+  {
+    return "NA";
+  }
+
+  std::ostringstream stream;
+  stream << std::fixed << std::setprecision(3) << value;
+  return stream.str();
+}
+
+void print_summary(const RuntimeConfig &config, const std::vector<SweepCase> &sweepCases,
+  uint64_t rawCpis, uint64_t analysedCpis, uint64_t skippedCpis)
+{
+  std::vector<const SweepCase *> ranked;
+  ranked.reserve(sweepCases.size());
+  for (const SweepCase &sweepCase : sweepCases)
+  {
+    ranked.push_back(&sweepCase);
+  }
+
+  std::sort(ranked.begin(), ranked.end(), [](const SweepCase *left, const SweepCase *right) {
+    if (left->detection_rate() != right->detection_rate())
+    {
+      return left->detection_rate() > right->detection_rate();
+    }
+    if (left->mean_peak_snr() != right->mean_peak_snr())
+    {
+      return left->mean_peak_snr() > right->mean_peak_snr();
+    }
+    return left->mean_detections() > right->mean_detections();
+  });
+
+  std::cout << "Replay file      : " << config.replayFile << "\n";
+  std::cout << "Raw CPIs read    : " << rawCpis << "\n";
+  std::cout << "Analysed CPIs    : " << analysedCpis << "\n";
+  std::cout << "Skipped CPIs     : " << skippedCpis << "\n";
+  std::cout << "Sweep cases      : " << sweepCases.size() << "\n\n";
+
+  std::cout << std::left
+    << std::setw(6) << "Rank"
+    << std::setw(8) << "Mode"
+    << std::setw(12) << "Pfa"
+    << std::setw(14) << "MinDoppHz"
+    << std::setw(12) << "MinDelay"
+    << std::setw(12) << "HitRate"
+    << std::setw(16) << "TotalDetect"
+    << std::setw(16) << "Mean/CPI"
+    << std::setw(16) << "MeanPeakSnr"
+    << "\n";
+
+  size_t rank = 1;
+  for (const SweepCase *sweepCase : ranked)
+  {
+    std::cout << std::left
+      << std::setw(6) << rank
+      << std::setw(8) << format_mode(sweepCase->mode)
+      << std::setw(12) << format_metric(sweepCase->pfa)
+      << std::setw(14) << format_metric(sweepCase->minDoppler)
+      << std::setw(12) << sweepCase->minDelay
+      << std::setw(12) << format_metric(sweepCase->detection_rate())
+      << std::setw(16) << sweepCase->totalDetections
+      << std::setw(16) << format_metric(sweepCase->mean_detections())
+      << std::setw(16) << format_metric(sweepCase->mean_peak_snr())
+      << "\n";
+    rank++;
+  }
+}
+}
+
+int main(int argc, char **argv)
+{
+  try
+  {
+    CliOptions options;
+    int exitCode = 0;
+    if (!parse_arguments(argc, argv, options, exitCode))
+    {
+      return exitCode;
+    }
+
+    RuntimeConfig config = load_runtime_config(options);
+    std::vector<SweepCase> sweepCases = build_sweep_cases(options, config);
+
+    std::ifstream replay(config.replayFile, std::ios::binary);
+    if (!replay.is_open())
+    {
+      throw std::runtime_error("Unable to open replay file '" + config.replayFile + "'");
+    }
+
+    const bool roundHamming = true;
+    Ambiguity ambiguity(config.ambiguityDelayMin, config.ambiguityDelayMax,
+      config.ambiguityDopplerMin, config.ambiguityDopplerMax, config.fs,
+      config.nSamples, roundHamming);
+    std::unique_ptr<WienerHopf> filter;
+    if (config.clutterEnable)
+    {
+      filter = std::make_unique<WienerHopf>(config.clutterDelayMin,
+        config.clutterDelayMax, config.nSamples);
+    }
+    Centroid centroid(config.nCentroid, config.nCentroid, 1.0 / config.tCpi);
+    Interpolate interpolate(true, true);
+
+    uint64_t rawCpis = 0;
+    uint64_t analysedCpis = 0;
+    uint64_t skippedCpis = 0;
+
+    while (options.maxCpis == 0 || rawCpis < options.maxCpis)
+    {
+      IqData x(config.nSamples);
+      IqData y(config.nSamples);
+      if (!read_blah2_iq_cpi(replay, config.nSamples, x, y))
+      {
+        break;
+      }
+      rawCpis++;
+
+      if (config.clutterEnable && !filter->process(&x, &y))
+      {
+        skippedCpis++;
+        continue;
+      }
+
+      Map<std::complex<double>> *map = ambiguity.process(&x, &y);
+      map->set_metrics();
+      analysedCpis++;
+
+      for (SweepCase &sweepCase : sweepCases)
+      {
+        std::unique_ptr<Detection> detectionPhase1 = sweepCase.detector.process(map);
+        std::unique_ptr<Detection> detectionPhase2 = centroid.process(detectionPhase1.get());
+        std::unique_ptr<Detection> detection = interpolate.process(detectionPhase2.get(), map);
+        sweepCase.record(*detection);
+      }
+    }
+
+    if (rawCpis == 0)
+    {
+      throw std::runtime_error("Replay file did not contain a full CPI for the configured sample rate and CPI length");
+    }
+    if (analysedCpis == 0)
+    {
+      throw std::runtime_error("No CPIs were analysed. Check clutter filter stability or disable clutter for the sweep");
+    }
+
+    print_summary(config, sweepCases, rawCpis, analysedCpis, skippedCpis);
+    return 0;
+  }
+  catch (const std::exception &error)
+  {
+    std::cerr << "testDetectionSweep: " << error.what() << std::endl;
+    return 1;
+  }
+}

--- a/test/comparison/TestDetectionSweep.cpp
+++ b/test/comparison/TestDetectionSweep.cpp
@@ -701,7 +701,6 @@ void validate_runtime_config(const RuntimeConfig &config)
   {
     throw std::runtime_error("Invalid capture/process config: fs and CPI must be positive finite values");
   }
-  config.delayBinWidthKm = Constants::c / static_cast<double>(config.fs) / 1000.0;
   if (config.nSamples == 0)
   {
     throw std::runtime_error("Derived CPI sample count is zero");
@@ -772,6 +771,7 @@ RuntimeConfig load_runtime_config(const CliOptions &options)
     throw std::runtime_error("Invalid derived CPI sample count");
   }
   config.nSamples = static_cast<uint32_t>(samplesPerCpi);
+  config.delayBinWidthKm = Constants::c / static_cast<double>(config.fs) / 1000.0;
 
   validate_runtime_config(config);
   return config;

--- a/test/comparison/TestDetectionSweep.cpp
+++ b/test/comparison/TestDetectionSweep.cpp
@@ -139,6 +139,12 @@ struct AdsbRunContext
   AdsbMatchConfig matchConfig;
 };
 
+struct LoadedAdsbSidecar
+{
+  std::optional<uint64_t> captureStartMs;
+  std::vector<AdsbSnapshot> snapshots;
+};
+
 struct SweepCase
 {
   double pfa;
@@ -543,7 +549,7 @@ void append_adsb_targets(const rapidjson::Value &target, const std::string &targ
   }
 }
 
-std::vector<AdsbSnapshot> load_adsb_snapshots(const std::string &path)
+LoadedAdsbSidecar load_adsb_sidecar(const std::string &path)
 {
   rapidjson::Document document;
   const std::string contents = read_text_file(path);
@@ -557,13 +563,24 @@ std::vector<AdsbSnapshot> load_adsb_snapshots(const std::string &path)
     throw std::runtime_error("ADS-B sidecar file must be a JSON array: '" + path + "'");
   }
 
-  std::vector<AdsbSnapshot> snapshots;
-  snapshots.reserve(document.Size());
+  LoadedAdsbSidecar sidecar;
+  sidecar.snapshots.reserve(document.Size());
   for (const rapidjson::Value &entry : document.GetArray())
   {
     if (!entry.IsObject())
     {
       throw std::runtime_error("ADS-B sidecar entries must be objects");
+    }
+
+    const auto captureStartMember = entry.FindMember("captureStartMs");
+    if (captureStartMember != entry.MemberEnd())
+    {
+      if (!captureStartMember->value.IsUint64())
+      {
+        throw std::runtime_error("ADS-B sidecar captureStartMs must be an unsigned integer");
+      }
+      sidecar.captureStartMs = captureStartMember->value.GetUint64();
+      continue;
     }
 
     const auto timestampMember = entry.FindMember("timestamp");
@@ -583,14 +600,14 @@ std::vector<AdsbSnapshot> load_adsb_snapshots(const std::string &path)
     {
       append_adsb_targets(target->value, target->name.GetString(), snapshot.targets);
     }
-    snapshots.push_back(std::move(snapshot));
+    sidecar.snapshots.push_back(std::move(snapshot));
   }
 
-  std::sort(snapshots.begin(), snapshots.end(), [](const AdsbSnapshot &left, const AdsbSnapshot &right) {
+  std::sort(sidecar.snapshots.begin(), sidecar.snapshots.end(), [](const AdsbSnapshot &left, const AdsbSnapshot &right) {
     return left.timestampMs < right.timestampMs;
   });
 
-  return snapshots;
+  return sidecar;
 }
 
 const AdsbSnapshot *find_adsb_snapshot(const std::vector<AdsbSnapshot> &snapshots,
@@ -631,6 +648,7 @@ const AdsbSnapshot *find_adsb_snapshot(const std::vector<AdsbSnapshot> &snapshot
   return &snapshots[bestIndex];
 }
 
+// Score each detection point independently against at most one ADS-B truth point.
 void record_adsb_match(const Detection &detection, const AdsbSnapshot &snapshot,
   double delayBinWidthKm, const AdsbMatchConfig &config, AdsbMatchSummary &summary)
 {
@@ -933,6 +951,7 @@ void print_summary(const RuntimeConfig &config, const std::vector<SweepCase> &sw
     std::cout << "ADS-B file       : " << adsbContext->file << "\n";
     std::cout << "ADS-B snapshots  : " << adsbContext->snapshotCount << "\n";
     std::cout << "Capture start ms : " << adsbContext->captureStartMs << "\n";
+    std::cout << "ADS-B scoring    : per detection point, not per CPI\n";
     std::cout << "ADS-B range win  : " << format_metric(adsbContext->matchConfig.delayWindowKm) << " km\n";
     std::cout << "ADS-B doppler win: " << format_metric(adsbContext->matchConfig.dopplerWindowHz) << " Hz\n";
     std::cout << "ADS-B max age ms : " << adsbContext->matchConfig.maxAgeMs << "\n\n";
@@ -953,11 +972,11 @@ void print_summary(const RuntimeConfig &config, const std::vector<SweepCase> &sw
   {
     std::cout
       << std::setw(12) << "TruthCPI"
-      << std::setw(12) << "MatchDet"
-      << std::setw(12) << "FalsePos"
-      << std::setw(12) << "MissedAdsb"
-      << std::setw(12) << "MatchPct"
-      << std::setw(12) << "FPRate";
+      << std::setw(12) << "MatchPts"
+      << std::setw(12) << "FalsePts"
+      << std::setw(12) << "MissedPts"
+      << std::setw(12) << "MatchPctPt"
+      << std::setw(12) << "FPRatePt";
   }
 
   std::cout
@@ -1007,7 +1026,7 @@ int main(int argc, char **argv)
 
     RuntimeConfig config = load_runtime_config(options);
     std::vector<SweepCase> sweepCases = build_sweep_cases(options, config);
-    std::vector<AdsbSnapshot> adsbSnapshots;
+    LoadedAdsbSidecar adsbSidecar;
     std::optional<AdsbRunContext> adsbContext;
     if (!options.adsbFile.empty())
     {
@@ -1019,6 +1038,11 @@ int main(int argc, char **argv)
       AdsbRunContext runContext;
       runContext.file = options.adsbFile;
       runContext.captureStartMs = options.captureStartMs;
+      adsbSidecar = load_adsb_sidecar(options.adsbFile);
+      if (runContext.captureStartMs == 0)
+      {
+        runContext.captureStartMs = adsbSidecar.captureStartMs.value_or(0);
+      }
       if (runContext.captureStartMs == 0)
       {
         runContext.captureStartMs = parse_capture_start_ms_from_replay_file(config.replayFile);
@@ -1035,12 +1059,11 @@ int main(int argc, char **argv)
           2000, static_cast<uint64_t>(std::llround(config.tCpi * 1000.0)));
       }
 
-      adsbSnapshots = load_adsb_snapshots(options.adsbFile);
-      if (adsbSnapshots.empty())
+      if (adsbSidecar.snapshots.empty())
       {
         throw std::runtime_error("ADS-B sidecar file did not contain any snapshots");
       }
-      runContext.snapshotCount = adsbSnapshots.size();
+      runContext.snapshotCount = adsbSidecar.snapshots.size();
       adsbContext = runContext;
     }
 
@@ -1094,7 +1117,7 @@ int main(int argc, char **argv)
         const uint64_t cpiOffsetMs = static_cast<uint64_t>(
           std::llround(static_cast<double>(rawCpis - 1) * config.tCpi * 1000.0));
         const uint64_t cpiTimestampMs = adsbContext->captureStartMs + cpiOffsetMs;
-        adsbSnapshot = find_adsb_snapshot(adsbSnapshots, cpiTimestampMs,
+        adsbSnapshot = find_adsb_snapshot(adsbSidecar.snapshots, cpiTimestampMs,
           adsbContext->matchConfig.maxAgeMs, adsbSnapshotCursor);
       }
 

--- a/test/comparison/TestDetectionSweep.cpp
+++ b/test/comparison/TestDetectionSweep.cpp
@@ -5,11 +5,14 @@
 #include "data/IqData.h"
 #include "data/Map.h"
 #include "data/Detection.h"
+#include "data/meta/Constants.h"
 #include "process/ambiguity/Ambiguity.h"
 #include "process/clutter/WienerHopf.h"
 #include "process/detection/Centroid.h"
 #include "process/detection/CfarDetector1D.h"
 #include "process/detection/Interpolate.h"
+
+#include <rapidjson/document.h>
 
 #include <ryml/ryml.hpp>
 #include <ryml/ryml_std.hpp>
@@ -24,9 +27,11 @@
 #include <limits>
 #include <memory>
 #include <numeric>
+#include <optional>
 #include <sstream>
 #include <stdexcept>
 #include <string>
+#include <ctime>
 #include <vector>
 
 namespace
@@ -40,6 +45,11 @@ struct CliOptions
   std::vector<int> minDelays;
   std::vector<CfarMode> modes;
   uint64_t maxCpis = 0;
+  std::string adsbFile;
+  double adsbDelayWindowKm = 1.0;
+  double adsbDopplerWindowHz = 10.0;
+  uint64_t adsbMaxAgeMs = 0;
+  uint64_t captureStartMs = 0;
 };
 
 struct RuntimeConfig
@@ -62,6 +72,71 @@ struct RuntimeConfig
   double minDoppler = 0.0;
   CfarMode cfarMode = CfarMode::CAGO;
   uint16_t nCentroid = 0;
+  double delayBinWidthKm = 0.0;
+};
+
+struct AdsbTarget
+{
+  double delayKm = 0.0;
+  double dopplerHz = 0.0;
+  std::string label;
+};
+
+struct AdsbSnapshot
+{
+  uint64_t timestampMs = 0;
+  std::vector<AdsbTarget> targets;
+};
+
+struct AdsbMatchConfig
+{
+  double delayWindowKm = 1.0;
+  double dopplerWindowHz = 10.0;
+  uint64_t maxAgeMs = 0;
+};
+
+struct AdsbMatchSummary
+{
+  uint64_t cpisWithTruth = 0;
+  uint64_t matchedDetections = 0;
+  uint64_t falsePositives = 0;
+  uint64_t missedTruthTargets = 0;
+
+  uint64_t scoredDetections() const
+  {
+    return matchedDetections + falsePositives;
+  }
+
+  uint64_t totalTruthTargets() const
+  {
+    return matchedDetections + missedTruthTargets;
+  }
+
+  double match_rate() const
+  {
+    if (scoredDetections() == 0)
+    {
+      return std::numeric_limits<double>::quiet_NaN();
+    }
+    return static_cast<double>(matchedDetections) / static_cast<double>(scoredDetections());
+  }
+
+  double false_positive_rate() const
+  {
+    if (scoredDetections() == 0)
+    {
+      return std::numeric_limits<double>::quiet_NaN();
+    }
+    return static_cast<double>(falsePositives) / static_cast<double>(scoredDetections());
+  }
+};
+
+struct AdsbRunContext
+{
+  std::string file;
+  uint64_t captureStartMs = 0;
+  size_t snapshotCount = 0;
+  AdsbMatchConfig matchConfig;
 };
 
 struct SweepCase
@@ -75,6 +150,7 @@ struct SweepCase
   uint64_t cpisWithDetections = 0;
   uint64_t totalDetections = 0;
   double peakSnrSum = 0.0;
+  AdsbMatchSummary adsb;
 
   SweepCase(double _pfa, int8_t nGuard, int8_t nTrain, int _minDelay,
     double _minDoppler, CfarMode _mode)
@@ -124,6 +200,16 @@ struct SweepCase
       return std::numeric_limits<double>::quiet_NaN();
     }
     return peakSnrSum / static_cast<double>(cpisWithDetections);
+  }
+
+  double adsb_match_rate() const
+  {
+    return adsb.match_rate();
+  }
+
+  double adsb_false_positive_rate() const
+  {
+    return adsb.false_positive_rate();
   }
 };
 
@@ -213,10 +299,17 @@ void print_help()
     << "  --min-delay <csv>          Comma-separated minimum delay thresholds in bins.\n"
     << "  --cfar-modes <csv>         Comma-separated modes from CA,CAGO.\n"
     << "  --max-cpis <n>             Limit replay processing to the first n CPIs.\n"
+    << "  --adsb-file <file.adsb>    Optional timestamped ADS-B sidecar file for truth scoring.\n"
+    << "  --adsb-delay-window-km <x> Match window in bistatic range km (default 1.0).\n"
+    << "  --adsb-doppler-window-hz <x> Match window in Doppler Hz (default 10.0).\n"
+    << "  --adsb-max-age-ms <n>      Max gap to nearest ADS-B snapshot before a CPI is unscored.\n"
+    << "  --capture-start-ms <n>     Capture start time in POSIX ms; inferred from replay file name if omitted.\n"
     << "  --help                     Show this help text.\n\n"
     << "Example:\n"
     << "  testDetectionSweep --config config/config.yml --replay-file /tmp/capture.iq \\\n"
-    << "    --pfa 1e-5,1e-4,1e-3 --min-doppler 5,10,15 --min-delay 0,5,10 --cfar-modes CAGO\n";
+    << "    --pfa 1e-5,1e-4,1e-3 --min-doppler 5,10,15 --min-delay 0,5,10 --cfar-modes CAGO\n"
+    << "  testDetectionSweep --config config/config.yml --replay-file /tmp/capture.iq \\\n"
+    << "    --adsb-file /tmp/capture.adsb --adsb-delay-window-km 1.0 --adsb-doppler-window-hz 10\n";
 }
 
 bool parse_arguments(int argc, char **argv, CliOptions &options, int &exitCode)
@@ -288,6 +381,31 @@ bool parse_arguments(int argc, char **argv, CliOptions &options, int &exitCode)
       options.maxCpis = static_cast<uint64_t>(std::stoull(require_value(argument)));
       continue;
     }
+    if (argument == "--adsb-file")
+    {
+      options.adsbFile = require_value(argument);
+      continue;
+    }
+    if (argument == "--adsb-delay-window-km")
+    {
+      options.adsbDelayWindowKm = std::stod(require_value(argument));
+      continue;
+    }
+    if (argument == "--adsb-doppler-window-hz")
+    {
+      options.adsbDopplerWindowHz = std::stod(require_value(argument));
+      continue;
+    }
+    if (argument == "--adsb-max-age-ms")
+    {
+      options.adsbMaxAgeMs = static_cast<uint64_t>(std::stoull(require_value(argument)));
+      continue;
+    }
+    if (argument == "--capture-start-ms")
+    {
+      options.captureStartMs = static_cast<uint64_t>(std::stoull(require_value(argument)));
+      continue;
+    }
 
     throw std::invalid_argument("Unknown argument '" + argument + "'");
   }
@@ -320,6 +438,259 @@ std::string read_text_file(const std::string &path)
   return buffer.str();
 }
 
+std::string get_basename(const std::string &path)
+{
+  const size_t separator = path.find_last_of("/\\");
+  if (separator == std::string::npos)
+  {
+    return path;
+  }
+  return path.substr(separator + 1);
+}
+
+uint64_t parse_capture_start_ms_from_replay_file(const std::string &replayFile)
+{
+  const std::string basename = get_basename(replayFile);
+  if (basename.size() < 15)
+  {
+    throw std::runtime_error("Unable to infer capture start timestamp from replay file '" + replayFile + "'");
+  }
+
+  std::tm timeInfo = {};
+  std::istringstream timestampStream(basename.substr(0, 15));
+  timestampStream >> std::get_time(&timeInfo, "%Y%m%d-%H%M%S");
+  if (timestampStream.fail())
+  {
+    throw std::runtime_error(
+      "Unable to infer capture start timestamp from replay file '" + replayFile +
+      "'. Pass --capture-start-ms explicitly.");
+  }
+
+  const std::time_t captureStart = std::mktime(&timeInfo);
+  if (captureStart < 0)
+  {
+    throw std::runtime_error(
+      "Unable to convert inferred replay timestamp for '" + replayFile + "'");
+  }
+
+  return static_cast<uint64_t>(captureStart) * 1000;
+}
+
+uint64_t absolute_diff_u64(uint64_t left, uint64_t right)
+{
+  return (left > right) ? (left - right) : (right - left);
+}
+
+std::vector<double> parse_adsb_axis_values(const rapidjson::Value &value, const std::string &fieldName)
+{
+  std::vector<double> values;
+  if (value.IsNumber())
+  {
+    values.push_back(value.GetDouble());
+    return values;
+  }
+
+  if (!value.IsArray())
+  {
+    throw std::runtime_error("ADS-B target field '" + fieldName + "' must be a number or array of numbers");
+  }
+
+  values.reserve(value.Size());
+  for (const rapidjson::Value &entry : value.GetArray())
+  {
+    if (!entry.IsNumber())
+    {
+      throw std::runtime_error("ADS-B target field '" + fieldName + "' contains a non-numeric value");
+    }
+    values.push_back(entry.GetDouble());
+  }
+  return values;
+}
+
+void append_adsb_targets(const rapidjson::Value &target, const std::string &targetId,
+  std::vector<AdsbTarget> &targets)
+{
+  if (!target.IsObject())
+  {
+    return;
+  }
+
+  const auto delayMember = target.FindMember("delay");
+  const auto dopplerMember = target.FindMember("doppler");
+  if (delayMember == target.MemberEnd() || dopplerMember == target.MemberEnd())
+  {
+    return;
+  }
+
+  std::vector<double> delays = parse_adsb_axis_values(delayMember->value, targetId + ".delay");
+  std::vector<double> dopplers = parse_adsb_axis_values(dopplerMember->value, targetId + ".doppler");
+  const size_t nPoints = std::min(delays.size(), dopplers.size());
+  if (nPoints == 0)
+  {
+    return;
+  }
+
+  std::string label = targetId;
+  const auto flightMember = target.FindMember("flight");
+  if (flightMember != target.MemberEnd() && flightMember->value.IsString())
+  {
+    label = flightMember->value.GetString();
+  }
+
+  for (size_t i = 0; i < nPoints; i++)
+  {
+    targets.push_back({delays[i], dopplers[i], label});
+  }
+}
+
+std::vector<AdsbSnapshot> load_adsb_snapshots(const std::string &path)
+{
+  rapidjson::Document document;
+  const std::string contents = read_text_file(path);
+  document.Parse(contents.c_str());
+  if (document.HasParseError())
+  {
+    throw std::runtime_error("Unable to parse ADS-B sidecar file '" + path + "'");
+  }
+  if (!document.IsArray())
+  {
+    throw std::runtime_error("ADS-B sidecar file must be a JSON array: '" + path + "'");
+  }
+
+  std::vector<AdsbSnapshot> snapshots;
+  snapshots.reserve(document.Size());
+  for (const rapidjson::Value &entry : document.GetArray())
+  {
+    if (!entry.IsObject())
+    {
+      throw std::runtime_error("ADS-B sidecar entries must be objects");
+    }
+
+    const auto timestampMember = entry.FindMember("timestamp");
+    const auto targetsMember = entry.FindMember("targets");
+    if (timestampMember == entry.MemberEnd() || !timestampMember->value.IsUint64())
+    {
+      throw std::runtime_error("ADS-B sidecar entries must contain an unsigned integer timestamp");
+    }
+    if (targetsMember == entry.MemberEnd() || !targetsMember->value.IsObject())
+    {
+      throw std::runtime_error("ADS-B sidecar entries must contain a targets object");
+    }
+
+    AdsbSnapshot snapshot;
+    snapshot.timestampMs = timestampMember->value.GetUint64();
+    for (auto target = targetsMember->value.MemberBegin(); target != targetsMember->value.MemberEnd(); ++target)
+    {
+      append_adsb_targets(target->value, target->name.GetString(), snapshot.targets);
+    }
+    snapshots.push_back(std::move(snapshot));
+  }
+
+  std::sort(snapshots.begin(), snapshots.end(), [](const AdsbSnapshot &left, const AdsbSnapshot &right) {
+    return left.timestampMs < right.timestampMs;
+  });
+
+  return snapshots;
+}
+
+const AdsbSnapshot *find_adsb_snapshot(const std::vector<AdsbSnapshot> &snapshots,
+  uint64_t timestampMs, uint64_t maxAgeMs, size_t &cursor)
+{
+  if (snapshots.empty())
+  {
+    return nullptr;
+  }
+
+  if (cursor >= snapshots.size())
+  {
+    cursor = snapshots.size() - 1;
+  }
+
+  while (cursor + 1 < snapshots.size() && snapshots[cursor + 1].timestampMs <= timestampMs)
+  {
+    cursor++;
+  }
+
+  size_t bestIndex = cursor;
+  uint64_t bestDistance = absolute_diff_u64(snapshots[bestIndex].timestampMs, timestampMs);
+  if (cursor + 1 < snapshots.size())
+  {
+    const uint64_t nextDistance = absolute_diff_u64(snapshots[cursor + 1].timestampMs, timestampMs);
+    if (nextDistance < bestDistance)
+    {
+      bestIndex = cursor + 1;
+      bestDistance = nextDistance;
+    }
+  }
+
+  if (bestDistance > maxAgeMs)
+  {
+    return nullptr;
+  }
+
+  return &snapshots[bestIndex];
+}
+
+void record_adsb_match(const Detection &detection, const AdsbSnapshot &snapshot,
+  double delayBinWidthKm, const AdsbMatchConfig &config, AdsbMatchSummary &summary)
+{
+  summary.cpisWithTruth++;
+
+  const std::vector<double> &detectionDelay = detection.get_delay();
+  const std::vector<double> &detectionDoppler = detection.get_doppler();
+  std::vector<bool> matchedTargets(snapshot.targets.size(), false);
+
+  for (size_t i = 0; i < detection.get_nDetections(); i++)
+  {
+    const double delayKm = detectionDelay[i] * delayBinWidthKm;
+    const double dopplerHz = detectionDoppler[i];
+    int bestIndex = -1;
+    double bestScore = std::numeric_limits<double>::infinity();
+
+    for (size_t j = 0; j < snapshot.targets.size(); j++)
+    {
+      if (matchedTargets[j])
+      {
+        continue;
+      }
+
+      const double delayError = std::abs(delayKm - snapshot.targets[j].delayKm);
+      const double dopplerError = std::abs(dopplerHz - snapshot.targets[j].dopplerHz);
+      if (delayError > config.delayWindowKm || dopplerError > config.dopplerWindowHz)
+      {
+        continue;
+      }
+
+      const double delayScore = delayError / config.delayWindowKm;
+      const double dopplerScore = dopplerError / config.dopplerWindowHz;
+      const double score = (delayScore * delayScore) + (dopplerScore * dopplerScore);
+      if (score < bestScore)
+      {
+        bestScore = score;
+        bestIndex = static_cast<int>(j);
+      }
+    }
+
+    if (bestIndex >= 0)
+    {
+      matchedTargets[static_cast<size_t>(bestIndex)] = true;
+      summary.matchedDetections++;
+    }
+    else
+    {
+      summary.falsePositives++;
+    }
+  }
+
+  for (bool matched : matchedTargets)
+  {
+    if (!matched)
+    {
+      summary.missedTruthTargets++;
+    }
+  }
+}
+
 void validate_runtime_config(const RuntimeConfig &config)
 {
   if (config.replayFile.empty())
@@ -330,6 +701,7 @@ void validate_runtime_config(const RuntimeConfig &config)
   {
     throw std::runtime_error("Invalid capture/process config: fs and CPI must be positive finite values");
   }
+  config.delayBinWidthKm = Constants::c / static_cast<double>(config.fs) / 1000.0;
   if (config.nSamples == 0)
   {
     throw std::runtime_error("Derived CPI sample count is zero");
@@ -502,8 +874,18 @@ std::string format_metric(double value)
   return stream.str();
 }
 
+double sortable_metric(double value)
+{
+  if (std::isnan(value))
+  {
+    return -std::numeric_limits<double>::infinity();
+  }
+  return value;
+}
+
 void print_summary(const RuntimeConfig &config, const std::vector<SweepCase> &sweepCases,
-  uint64_t rawCpis, uint64_t analysedCpis, uint64_t skippedCpis)
+  uint64_t rawCpis, uint64_t analysedCpis, uint64_t skippedCpis,
+  const std::optional<AdsbRunContext> &adsbContext)
 {
   std::vector<const SweepCase *> ranked;
   ranked.reserve(sweepCases.size());
@@ -512,14 +894,30 @@ void print_summary(const RuntimeConfig &config, const std::vector<SweepCase> &sw
     ranked.push_back(&sweepCase);
   }
 
-  std::sort(ranked.begin(), ranked.end(), [](const SweepCase *left, const SweepCase *right) {
-    if (left->detection_rate() != right->detection_rate())
+  const bool hasAdsb = adsbContext.has_value();
+  std::sort(ranked.begin(), ranked.end(), [hasAdsb](const SweepCase *left, const SweepCase *right) {
+    if (hasAdsb)
     {
-      return left->detection_rate() > right->detection_rate();
+      if (sortable_metric(left->adsb_match_rate()) != sortable_metric(right->adsb_match_rate()))
+      {
+        return sortable_metric(left->adsb_match_rate()) > sortable_metric(right->adsb_match_rate());
+      }
+      if (sortable_metric(left->adsb_false_positive_rate()) != sortable_metric(right->adsb_false_positive_rate()))
+      {
+        return sortable_metric(left->adsb_false_positive_rate()) < sortable_metric(right->adsb_false_positive_rate());
+      }
+      if (left->adsb.matchedDetections != right->adsb.matchedDetections)
+      {
+        return left->adsb.matchedDetections > right->adsb.matchedDetections;
+      }
     }
-    if (left->mean_peak_snr() != right->mean_peak_snr())
+    if (sortable_metric(left->detection_rate()) != sortable_metric(right->detection_rate()))
     {
-      return left->mean_peak_snr() > right->mean_peak_snr();
+      return sortable_metric(left->detection_rate()) > sortable_metric(right->detection_rate());
+    }
+    if (sortable_metric(left->mean_peak_snr()) != sortable_metric(right->mean_peak_snr()))
+    {
+      return sortable_metric(left->mean_peak_snr()) > sortable_metric(right->mean_peak_snr());
     }
     return left->mean_detections() > right->mean_detections();
   });
@@ -530,6 +928,16 @@ void print_summary(const RuntimeConfig &config, const std::vector<SweepCase> &sw
   std::cout << "Skipped CPIs     : " << skippedCpis << "\n";
   std::cout << "Sweep cases      : " << sweepCases.size() << "\n\n";
 
+  if (hasAdsb)
+  {
+    std::cout << "ADS-B file       : " << adsbContext->file << "\n";
+    std::cout << "ADS-B snapshots  : " << adsbContext->snapshotCount << "\n";
+    std::cout << "Capture start ms : " << adsbContext->captureStartMs << "\n";
+    std::cout << "ADS-B range win  : " << format_metric(adsbContext->matchConfig.delayWindowKm) << " km\n";
+    std::cout << "ADS-B doppler win: " << format_metric(adsbContext->matchConfig.dopplerWindowHz) << " Hz\n";
+    std::cout << "ADS-B max age ms : " << adsbContext->matchConfig.maxAgeMs << "\n\n";
+  }
+
   std::cout << std::left
     << std::setw(6) << "Rank"
     << std::setw(8) << "Mode"
@@ -539,7 +947,20 @@ void print_summary(const RuntimeConfig &config, const std::vector<SweepCase> &sw
     << std::setw(12) << "HitRate"
     << std::setw(16) << "TotalDetect"
     << std::setw(16) << "Mean/CPI"
-    << std::setw(16) << "MeanPeakSnr"
+    << std::setw(16) << "MeanPeakSnr";
+
+  if (hasAdsb)
+  {
+    std::cout
+      << std::setw(12) << "TruthCPI"
+      << std::setw(12) << "MatchDet"
+      << std::setw(12) << "FalsePos"
+      << std::setw(12) << "MissedAdsb"
+      << std::setw(12) << "MatchPct"
+      << std::setw(12) << "FPRate";
+  }
+
+  std::cout
     << "\n";
 
   size_t rank = 1;
@@ -554,8 +975,20 @@ void print_summary(const RuntimeConfig &config, const std::vector<SweepCase> &sw
       << std::setw(12) << format_metric(sweepCase->detection_rate())
       << std::setw(16) << sweepCase->totalDetections
       << std::setw(16) << format_metric(sweepCase->mean_detections())
-      << std::setw(16) << format_metric(sweepCase->mean_peak_snr())
-      << "\n";
+      << std::setw(16) << format_metric(sweepCase->mean_peak_snr());
+
+    if (hasAdsb)
+    {
+      std::cout
+        << std::setw(12) << sweepCase->adsb.cpisWithTruth
+        << std::setw(12) << sweepCase->adsb.matchedDetections
+        << std::setw(12) << sweepCase->adsb.falsePositives
+        << std::setw(12) << sweepCase->adsb.missedTruthTargets
+        << std::setw(12) << format_metric(sweepCase->adsb_match_rate())
+        << std::setw(12) << format_metric(sweepCase->adsb_false_positive_rate());
+    }
+
+    std::cout << "\n";
     rank++;
   }
 }
@@ -574,6 +1007,42 @@ int main(int argc, char **argv)
 
     RuntimeConfig config = load_runtime_config(options);
     std::vector<SweepCase> sweepCases = build_sweep_cases(options, config);
+    std::vector<AdsbSnapshot> adsbSnapshots;
+    std::optional<AdsbRunContext> adsbContext;
+    if (!options.adsbFile.empty())
+    {
+      if (!(options.adsbDelayWindowKm > 0.0) || !(options.adsbDopplerWindowHz > 0.0))
+      {
+        throw std::runtime_error("ADS-B match windows must be positive");
+      }
+
+      AdsbRunContext runContext;
+      runContext.file = options.adsbFile;
+      runContext.captureStartMs = options.captureStartMs;
+      if (runContext.captureStartMs == 0)
+      {
+        runContext.captureStartMs = parse_capture_start_ms_from_replay_file(config.replayFile);
+      }
+      runContext.matchConfig.delayWindowKm = options.adsbDelayWindowKm;
+      runContext.matchConfig.dopplerWindowHz = options.adsbDopplerWindowHz;
+      if (options.adsbMaxAgeMs != 0)
+      {
+        runContext.matchConfig.maxAgeMs = options.adsbMaxAgeMs;
+      }
+      else
+      {
+        runContext.matchConfig.maxAgeMs = std::max<uint64_t>(
+          2000, static_cast<uint64_t>(std::llround(config.tCpi * 1000.0)));
+      }
+
+      adsbSnapshots = load_adsb_snapshots(options.adsbFile);
+      if (adsbSnapshots.empty())
+      {
+        throw std::runtime_error("ADS-B sidecar file did not contain any snapshots");
+      }
+      runContext.snapshotCount = adsbSnapshots.size();
+      adsbContext = runContext;
+    }
 
     std::ifstream replay(config.replayFile, std::ios::binary);
     if (!replay.is_open())
@@ -597,6 +1066,7 @@ int main(int argc, char **argv)
     uint64_t rawCpis = 0;
     uint64_t analysedCpis = 0;
     uint64_t skippedCpis = 0;
+    size_t adsbSnapshotCursor = 0;
 
     while (options.maxCpis == 0 || rawCpis < options.maxCpis)
     {
@@ -618,12 +1088,27 @@ int main(int argc, char **argv)
       map->set_metrics();
       analysedCpis++;
 
+      const AdsbSnapshot *adsbSnapshot = nullptr;
+      if (adsbContext.has_value())
+      {
+        const uint64_t cpiOffsetMs = static_cast<uint64_t>(
+          std::llround(static_cast<double>(rawCpis - 1) * config.tCpi * 1000.0));
+        const uint64_t cpiTimestampMs = adsbContext->captureStartMs + cpiOffsetMs;
+        adsbSnapshot = find_adsb_snapshot(adsbSnapshots, cpiTimestampMs,
+          adsbContext->matchConfig.maxAgeMs, adsbSnapshotCursor);
+      }
+
       for (SweepCase &sweepCase : sweepCases)
       {
         std::unique_ptr<Detection> detectionPhase1 = sweepCase.detector.process(map);
         std::unique_ptr<Detection> detectionPhase2 = centroid.process(detectionPhase1.get());
         std::unique_ptr<Detection> detection = interpolate.process(detectionPhase2.get(), map);
         sweepCase.record(*detection);
+        if (adsbSnapshot != nullptr)
+        {
+          record_adsb_match(*detection, *adsbSnapshot, config.delayBinWidthKm,
+            adsbContext->matchConfig, sweepCase.adsb);
+        }
       }
     }
 
@@ -636,7 +1121,13 @@ int main(int argc, char **argv)
       throw std::runtime_error("No CPIs were analysed. Check clutter filter stability or disable clutter for the sweep");
     }
 
-    print_summary(config, sweepCases, rawCpis, analysedCpis, skippedCpis);
+    if (adsbContext.has_value() && !sweepCases.empty() && sweepCases.front().adsb.cpisWithTruth == 0)
+    {
+      std::cerr << "Warning: ADS-B sidecar was loaded but no analysed CPI had a nearby truth snapshot within "
+        << adsbContext->matchConfig.maxAgeMs << " ms" << std::endl;
+    }
+
+    print_summary(config, sweepCases, rawCpis, analysedCpis, skippedCpis, adsbContext);
     return 0;
   }
   catch (const std::exception &error)

--- a/test/data/README.md
+++ b/test/data/README.md
@@ -6,4 +6,4 @@ A set of golden data used for testing.
 
 | File  | Description |
 | ------------- | ------------- |
-| `todo.rspduo.iq`  | Stores 1 CPI of IQ data for the SDRPlay RspDuo.  |
+| `todo.rspduo.iq`  | Stores 1 CPI of canonical Blah2 two-channel IQ data in a single interleaved file captured on an SDRPlay RspDuo.  |

--- a/test/unit/capture/TestSource.cpp
+++ b/test/unit/capture/TestSource.cpp
@@ -55,11 +55,12 @@ public:
 class TestSourceDevice : public Source
 {
 private:
-  bool saveIqEnabled = true;
+  std::atomic<bool> saveIqEnabled{true};
 
 public:
-  explicit TestSourceDevice(const std::string &type = "Test")
-    : Source(type, 1, 1, "", &saveIqEnabled)
+  explicit TestSourceDevice(const std::string &type = "Test",
+    const std::string &path = "")
+    : Source(type, 1, 1, path, &saveIqEnabled)
   {
   }
 
@@ -144,6 +145,15 @@ TEST_CASE("Replay_Blah2IqFileThrowsOnOpenFailure", "[capture][source][replay]")
 
   CHECK_THROWS_AS(device.replay(&reference, &surveillance,
     tempFile.path().string(), false), std::runtime_error);
+}
+
+TEST_CASE("Open_FileThrowsOnCreateFailure", "[capture][source][save]")
+{
+  const std::string missingDirectoryPath =
+    make_unique_test_path("blah2-test-missing-open").string() + "/";
+  TestSourceDevice device("HackRF", missingDirectoryPath);
+
+  CHECK_THROWS_AS(device.open_file(), std::runtime_error);
 }
 
 TEST_CASE("Write_Blah2IqSamplesUsesCanonicalInterleaving", "[capture][source][save]")

--- a/test/unit/capture/TestSource.cpp
+++ b/test/unit/capture/TestSource.cpp
@@ -1,0 +1,122 @@
+/// @file TestSource.cpp
+/// @brief Unit tests for generic Blah2 IQ file capture/replay helpers.
+/// @author 30hours
+
+#include <catch2/catch_test_macros.hpp>
+
+#include "capture/Source.h"
+#include "data/IqData.h"
+
+#include <complex>
+#include <filesystem>
+#include <fstream>
+#include <string>
+#include <vector>
+
+namespace
+{
+class TestSourceDevice : public Source
+{
+public:
+  explicit TestSourceDevice(const std::string &type = "Test")
+    : Source(type, 1, 1, "", nullptr)
+  {
+  }
+
+  void process(IqData *buffer1, IqData *buffer2) override
+  {
+    (void)buffer1;
+    (void)buffer2;
+  }
+
+  void start() override
+  {
+  }
+
+  void stop() override
+  {
+  }
+
+  void replay(IqData *buffer1, IqData *buffer2, std::string file, bool loop) override
+  {
+    replay_blah2_iq_file(buffer1, buffer2, file, loop);
+  }
+
+  void open_test_file(const std::filesystem::path &path)
+  {
+    saveIqFile.open(path, std::ios::binary | std::ios::trunc);
+  }
+
+  void write_test_samples(const std::vector<std::complex<float>> &reference,
+    const std::vector<std::complex<float>> &surveillance)
+  {
+    write_blah2_iq_samples(reference.data(), surveillance.data(), reference.size());
+  }
+
+  void close_test_file()
+  {
+    close_file();
+  }
+};
+}
+
+TEST_CASE("Replay_Blah2IqFileLoadsCanonicalFrames", "[capture][source][replay]")
+{
+  const std::filesystem::path filePath = std::filesystem::temp_directory_path() / "blah2-test-replay.iq";
+  const int16_t raw[] = {1, -2, 3, -4, 5, -6, 7, -8};
+
+  {
+    std::ofstream file(filePath, std::ios::binary | std::ios::trunc);
+    REQUIRE(file.is_open());
+    file.write(reinterpret_cast<const char *>(raw), sizeof(raw));
+  }
+
+  IqData reference(4);
+  IqData surveillance(4);
+  TestSourceDevice device("HackRF");
+  device.replay(&reference, &surveillance, filePath.string(), false);
+
+  REQUIRE(reference.get_length() == 2);
+  REQUIRE(surveillance.get_length() == 2);
+  CHECK(reference.at(0) == std::complex<double>(1.0, -2.0));
+  CHECK(surveillance.at(0) == std::complex<double>(3.0, -4.0));
+  CHECK(reference.at(1) == std::complex<double>(5.0, -6.0));
+  CHECK(surveillance.at(1) == std::complex<double>(7.0, -8.0));
+
+  std::filesystem::remove(filePath);
+}
+
+TEST_CASE("Write_Blah2IqSamplesUsesCanonicalInterleaving", "[capture][source][save]")
+{
+  const std::filesystem::path filePath = std::filesystem::temp_directory_path() / "blah2-test-write.iq";
+  TestSourceDevice device("Usrp");
+  const std::vector<std::complex<float>> reference = {
+    {1.4f, -2.6f},
+    {40000.0f, -40000.0f}
+  };
+  const std::vector<std::complex<float>> surveillance = {
+    {3.5f, -4.5f},
+    {9.2f, -10.2f}
+  };
+
+  device.open_test_file(filePath);
+  device.write_test_samples(reference, surveillance);
+  device.close_test_file();
+
+  std::ifstream file(filePath, std::ios::binary);
+  REQUIRE(file.is_open());
+  std::vector<int16_t> raw(8, 0);
+  file.read(reinterpret_cast<char *>(raw.data()), static_cast<std::streamsize>(raw.size() * sizeof(int16_t)));
+  REQUIRE(file.gcount() == static_cast<std::streamsize>(raw.size() * sizeof(int16_t)));
+
+  CHECK(raw[0] == 1);
+  CHECK(raw[1] == -3);
+  CHECK(raw[2] == 4);
+  CHECK(raw[3] == -5);
+  CHECK(raw[4] == 32767);
+  CHECK(raw[5] == -32768);
+  CHECK(raw[6] == 9);
+  CHECK(raw[7] == -10);
+
+  std::filesystem::remove(filePath);
+}

--- a/test/unit/capture/TestSource.cpp
+++ b/test/unit/capture/TestSource.cpp
@@ -7,19 +7,59 @@
 #include "capture/Source.h"
 #include "data/IqData.h"
 
+#include <atomic>
+#include <chrono>
 #include <complex>
 #include <filesystem>
 #include <fstream>
+#include <limits>
 #include <string>
+#include <system_error>
 #include <vector>
 
 namespace
 {
+std::filesystem::path make_unique_test_path(const std::string &prefix)
+{
+  static std::atomic<uint64_t> uniqueId{0};
+  return std::filesystem::temp_directory_path() /
+    (prefix + "-" + std::to_string(
+      std::chrono::steady_clock::now().time_since_epoch().count())
+      + "-" + std::to_string(uniqueId.fetch_add(1, std::memory_order_relaxed))
+      + ".iq");
+}
+
+class ScopedTempFile
+{
+private:
+  std::filesystem::path filePath;
+
+public:
+  explicit ScopedTempFile(const std::string &prefix)
+    : filePath(make_unique_test_path(prefix))
+  {
+  }
+
+  ~ScopedTempFile()
+  {
+    std::error_code error;
+    std::filesystem::remove(filePath, error);
+  }
+
+  const std::filesystem::path &path() const
+  {
+    return filePath;
+  }
+};
+
 class TestSourceDevice : public Source
 {
+private:
+  bool saveIqEnabled = true;
+
 public:
   explicit TestSourceDevice(const std::string &type = "Test")
-    : Source(type, 1, 1, "", nullptr)
+    : Source(type, 1, 1, "", &saveIqEnabled)
   {
   }
 
@@ -48,9 +88,19 @@ public:
   }
 
   void write_test_samples(const std::vector<std::complex<float>> &reference,
-    const std::vector<std::complex<float>> &surveillance)
+    const std::vector<std::complex<float>> &surveillance, double scale = 1.0)
   {
-    write_blah2_iq_samples(reference.data(), surveillance.data(), reference.size());
+    write_blah2_iq_samples(reference.data(), surveillance.data(), reference.size(), scale);
+  }
+
+  void append_test_byte_samples(size_t channelIndex, const std::vector<int8_t> &samples)
+  {
+    append_blah2_paired_iq_samples(channelIndex, samples.data(), samples.size() / 2);
+  }
+
+  static size_t get_max_pending_test_samples()
+  {
+    return maxPendingBlah2PairedIqSamples;
   }
 
   void close_test_file()
@@ -62,7 +112,8 @@ public:
 
 TEST_CASE("Replay_Blah2IqFileLoadsCanonicalFrames", "[capture][source][replay]")
 {
-  const std::filesystem::path filePath = std::filesystem::temp_directory_path() / "blah2-test-replay.iq";
+  const ScopedTempFile tempFile("blah2-test-replay");
+  const std::filesystem::path &filePath = tempFile.path();
   const int16_t raw[] = {1, -2, 3, -4, 5, -6, 7, -8};
 
   {
@@ -82,13 +133,23 @@ TEST_CASE("Replay_Blah2IqFileLoadsCanonicalFrames", "[capture][source][replay]")
   CHECK(surveillance.at(0) == std::complex<double>(3.0, -4.0));
   CHECK(reference.at(1) == std::complex<double>(5.0, -6.0));
   CHECK(surveillance.at(1) == std::complex<double>(7.0, -8.0));
+}
 
-  std::filesystem::remove(filePath);
+TEST_CASE("Replay_Blah2IqFileThrowsOnOpenFailure", "[capture][source][replay]")
+{
+  const ScopedTempFile tempFile("blah2-test-missing-replay");
+  IqData reference(4);
+  IqData surveillance(4);
+  TestSourceDevice device("HackRF");
+
+  CHECK_THROWS_AS(device.replay(&reference, &surveillance,
+    tempFile.path().string(), false), std::runtime_error);
 }
 
 TEST_CASE("Write_Blah2IqSamplesUsesCanonicalInterleaving", "[capture][source][save]")
 {
-  const std::filesystem::path filePath = std::filesystem::temp_directory_path() / "blah2-test-write.iq";
+  const ScopedTempFile tempFile("blah2-test-write");
+  const std::filesystem::path &filePath = tempFile.path();
   TestSourceDevice device("Usrp");
   const std::vector<std::complex<float>> reference = {
     {1.4f, -2.6f},
@@ -117,6 +178,127 @@ TEST_CASE("Write_Blah2IqSamplesUsesCanonicalInterleaving", "[capture][source][sa
   CHECK(raw[5] == -32768);
   CHECK(raw[6] == 9);
   CHECK(raw[7] == -10);
+}
 
-  std::filesystem::remove(filePath);
+TEST_CASE("Write_Blah2IqSamplesScalesNormalizedFloats", "[capture][source][save]")
+{
+  const ScopedTempFile tempFile("blah2-test-scaled-write");
+  const std::filesystem::path &filePath = tempFile.path();
+  TestSourceDevice device("Usrp");
+  const std::vector<std::complex<float>> reference = {
+    {0.5f, -0.5f}
+  };
+  const std::vector<std::complex<float>> surveillance = {
+    {-1.0f, 1.0f}
+  };
+
+  device.open_test_file(filePath);
+  device.write_test_samples(reference, surveillance,
+    static_cast<double>(std::numeric_limits<int16_t>::max()));
+  device.close_test_file();
+
+  std::ifstream file(filePath, std::ios::binary);
+  REQUIRE(file.is_open());
+  std::vector<int16_t> raw(4, 0);
+  file.read(reinterpret_cast<char *>(raw.data()), static_cast<std::streamsize>(raw.size() * sizeof(int16_t)));
+  REQUIRE(file.gcount() == static_cast<std::streamsize>(raw.size() * sizeof(int16_t)));
+
+  CHECK(raw[0] == 16384);
+  CHECK(raw[1] == -16384);
+  CHECK(raw[2] == -32767);
+  CHECK(raw[3] == 32767);
+}
+
+TEST_CASE("PairedIqSamplesWriteOnlyAlignedChannelPairs", "[capture][source][save]")
+{
+  const ScopedTempFile tempFile("blah2-test-paired-write");
+  const std::filesystem::path &filePath = tempFile.path();
+  TestSourceDevice device("HackRF");
+
+  device.open_test_file(filePath);
+  device.append_test_byte_samples(0, {1, 2, 3, 4});
+  device.append_test_byte_samples(1, {5, 6});
+  device.append_test_byte_samples(1, {7, 8});
+  device.close_test_file();
+
+  std::ifstream file(filePath, std::ios::binary);
+  REQUIRE(file.is_open());
+  std::vector<int16_t> raw(8, 0);
+  file.read(reinterpret_cast<char *>(raw.data()), static_cast<std::streamsize>(raw.size() * sizeof(int16_t)));
+  REQUIRE(file.gcount() == static_cast<std::streamsize>(raw.size() * sizeof(int16_t)));
+
+  CHECK(raw[0] == 1);
+  CHECK(raw[1] == 2);
+  CHECK(raw[2] == 5);
+  CHECK(raw[3] == 6);
+  CHECK(raw[4] == 3);
+  CHECK(raw[5] == 4);
+  CHECK(raw[6] == 7);
+  CHECK(raw[7] == 8);
+}
+
+TEST_CASE("PairedIqSamplesDropOldestWhenChannelBacklogGrows", "[capture][source][save]")
+{
+  const ScopedTempFile tempFile("blah2-test-paired-cap");
+  const std::filesystem::path &filePath = tempFile.path();
+  TestSourceDevice device("Kraken");
+  const size_t maxPendingSamples = TestSourceDevice::get_max_pending_test_samples();
+  std::vector<int8_t> referenceSamples((maxPendingSamples + 2) * 2, 0);
+
+  for (size_t i = 0; i < maxPendingSamples + 2; i++)
+  {
+    referenceSamples[2 * i] = 20;
+    referenceSamples[2 * i + 1] = 21;
+  }
+  referenceSamples[0] = 10;
+  referenceSamples[1] = 11;
+  referenceSamples[2] = 12;
+  referenceSamples[3] = 13;
+
+  device.open_test_file(filePath);
+  device.append_test_byte_samples(0, referenceSamples);
+  device.append_test_byte_samples(1, {40, 41});
+  device.close_test_file();
+
+  std::ifstream file(filePath, std::ios::binary);
+  REQUIRE(file.is_open());
+  std::vector<int16_t> raw(4, 0);
+  file.read(reinterpret_cast<char *>(raw.data()), static_cast<std::streamsize>(raw.size() * sizeof(int16_t)));
+  REQUIRE(file.gcount() == static_cast<std::streamsize>(raw.size() * sizeof(int16_t)));
+
+  CHECK(raw[0] == 20);
+  CHECK(raw[1] == 21);
+  CHECK(raw[2] == 40);
+  CHECK(raw[3] == 41);
+}
+
+TEST_CASE("Close_FileClearsPendingPairedSamples", "[capture][source][save]")
+{
+  const ScopedTempFile firstTempFile("blah2-test-close-clear-1");
+  const ScopedTempFile secondTempFile("blah2-test-close-clear-2");
+  const std::filesystem::path &firstFilePath = firstTempFile.path();
+  const std::filesystem::path &secondFilePath = secondTempFile.path();
+  TestSourceDevice device("HackRF");
+
+  device.open_test_file(firstFilePath);
+  device.append_test_byte_samples(0, {1, 2});
+  device.close_test_file();
+
+  REQUIRE(std::filesystem::file_size(firstFilePath) == 0);
+
+  device.open_test_file(secondFilePath);
+  device.append_test_byte_samples(1, {5, 6});
+  device.append_test_byte_samples(0, {7, 8});
+  device.close_test_file();
+
+  std::ifstream file(secondFilePath, std::ios::binary);
+  REQUIRE(file.is_open());
+  std::vector<int16_t> raw(4, 0);
+  file.read(reinterpret_cast<char *>(raw.data()), static_cast<std::streamsize>(raw.size() * sizeof(int16_t)));
+  REQUIRE(file.gcount() == static_cast<std::streamsize>(raw.size() * sizeof(int16_t)));
+
+  CHECK(raw[0] == 7);
+  CHECK(raw[1] == 8);
+  CHECK(raw[2] == 5);
+  CHECK(raw[3] == 6);
 }

--- a/test/unit/data/TestIqData.cpp
+++ b/test/unit/data/TestIqData.cpp
@@ -4,6 +4,7 @@
 
 #include <catch2/catch_test_macros.hpp>
 
+#include <atomic>
 #include <thread>
 #include <chrono>
 #include <stdexcept>
@@ -25,19 +26,39 @@ TEST_CASE("Wait_For_Max_Length_Blocks_Until_Buffer_Has_Space", "[iqdata]")
   iqData.push_back({2.0, 0.0});
   iqData.unlock_and_notify();
 
-  bool waiterReleased = false;
+  std::atomic<bool> waiterStarted{false};
+  std::atomic<bool> waiterReleased{false};
   std::thread waiter([&]() {
+    waiterStarted.store(true, std::memory_order_release);
     iqData.wait_for_max_length(1);
-    waiterReleased = true;
+    waiterReleased.store(true, std::memory_order_release);
   });
 
-  std::this_thread::sleep_for(std::chrono::milliseconds(20));
-  CHECK(waiterReleased == false);
+  const auto waitForState = [](const std::atomic<bool> &state,
+    std::chrono::milliseconds timeout) {
+    const auto deadline = std::chrono::steady_clock::now() + timeout;
+    while (!state.load(std::memory_order_acquire)
+      && std::chrono::steady_clock::now() < deadline)
+    {
+      std::this_thread::yield();
+    }
+    return state.load(std::memory_order_acquire);
+  };
+
+  const bool waiterStartedInTime = waitForState(waiterStarted,
+    std::chrono::milliseconds(200));
+  const bool waiterReleasedWhileFull = waiterReleased.load(
+    std::memory_order_acquire);
 
   iqData.lock();
   (void)iqData.pop_front();
   iqData.unlock_and_notify();
 
+  const bool waiterReleasedInTime = waitForState(waiterReleased,
+    std::chrono::milliseconds(200));
   waiter.join();
-  CHECK(waiterReleased == true);
+
+  CHECK(waiterStartedInTime == true);
+  CHECK(waiterReleasedWhileFull == false);
+  CHECK(waiterReleasedInTime == true);
 }

--- a/test/unit/data/TestIqData.cpp
+++ b/test/unit/data/TestIqData.cpp
@@ -4,6 +4,8 @@
 
 #include <catch2/catch_test_macros.hpp>
 
+#include <thread>
+#include <chrono>
 #include <stdexcept>
 
 #include "data/IqData.h"
@@ -13,4 +15,29 @@ TEST_CASE("Wait_For_Min_Length_Rejects_Impossible_Request", "[iqdata]")
   IqData iqData(8);
 
   CHECK_THROWS_AS(iqData.wait_for_min_length(9), std::invalid_argument);
+}
+
+TEST_CASE("Wait_For_Max_Length_Blocks_Until_Buffer_Has_Space", "[iqdata]")
+{
+  IqData iqData(2);
+  iqData.lock();
+  iqData.push_back({1.0, 0.0});
+  iqData.push_back({2.0, 0.0});
+  iqData.unlock_and_notify();
+
+  bool waiterReleased = false;
+  std::thread waiter([&]() {
+    iqData.wait_for_max_length(1);
+    waiterReleased = true;
+  });
+
+  std::this_thread::sleep_for(std::chrono::milliseconds(20));
+  CHECK(waiterReleased == false);
+
+  iqData.lock();
+  (void)iqData.pop_front();
+  iqData.unlock_and_notify();
+
+  waiter.join();
+  CHECK(waiterReleased == true);
 }


### PR DESCRIPTION
- Improved the IQ data detection test harness to test the effect of applying different config settings 
- Added ADSB data to the test harness so good detections can be identified and counted as True Positives that can assess the efficacy of testing different config settings
- Reflected changes on the user guide
- Changed the default CFAR detection algorithm to CAGO-CFAR
- Changed the way IQ data recording in the UI
- De-coupled IQ detection from inside the device capture file to a generic function that sits outside
- Test IQ data capture with HackRF and files are being captured.