### PR TITLE
first implementation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -69,6 +69,7 @@ target_link_libraries(blah2 PRIVATE
   ryml::ryml
   httplib::httplib
   armadillo
+  ${CMAKE_DL_LIBS}
   ${UHD_LIBRARIES}
   fftw3
   fftw3_threads
@@ -181,6 +182,8 @@ add_executable(testKraken
 )
 target_link_libraries(testKraken PRIVATE
   Catch2::Catch2WithMain
+  Threads::Threads
+  ${CMAKE_DL_LIBS}
   fftw3
   rtlsdr
 )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -173,6 +173,20 @@ target_link_libraries(testSource PRIVATE
 set_target_properties(testSource PROPERTIES
   RUNTIME_OUTPUT_DIRECTORY "${PROJECT_BINARY_TEST_UNIT_DIR}")
 
+add_executable(testKraken
+  test/unit/capture/TestKraken.cpp
+  src/capture/kraken/Kraken.cpp
+  src/capture/Source.cpp
+  src/data/IqData.cpp
+)
+target_link_libraries(testKraken PRIVATE
+  Catch2::Catch2WithMain
+  fftw3
+  rtlsdr
+)
+set_target_properties(testKraken PROPERTIES
+  RUNTIME_OUTPUT_DIRECTORY "${PROJECT_BINARY_TEST_UNIT_DIR}")
+
 add_executable(testDetectionSweep
   test/comparison/TestDetectionSweep.cpp
   src/data/IqData.cpp
@@ -200,6 +214,7 @@ add_test(NAME testAmbiguity COMMAND testAmbiguity)
 add_test(NAME testIqData COMMAND testIqData)
 add_test(NAME testTracker COMMAND testTracker)
 add_test(NAME testSource COMMAND testSource)
+add_test(NAME testKraken COMMAND testKraken)
 add_test(NAME testDetectionPhaseA COMMAND testDetectionPhaseA)
 add_test(NAME testDetectionPhaseB COMMAND testDetectionPhaseB)
 add_test(NAME testCentroid COMMAND testCentroid)

--- a/config/config-kraken.yml
+++ b/config/config-kraken.yml
@@ -5,6 +5,7 @@ capture:
     type: "Kraken"
     gain: [15.0, 15.0]
     alignment:
+      enabled: true # Enable startup sample-time alignment and periodic drift correction.
       windowCount: 3 # Number of consecutive windows used to establish startup/recheck consensus.
       consensusToleranceSamples: 16 # Maximum lag spread allowed across the alignment windows.
       recheckIntervalMinutes: 10 # Interval between drift rechecks after startup alignment.

--- a/config/config-kraken.yml
+++ b/config/config-kraken.yml
@@ -4,6 +4,10 @@ capture:
   device:
     type: "Kraken"
     gain: [15.0, 15.0]
+    alignment:
+      windowCount: 3 # Number of consecutive windows used to establish startup/recheck consensus.
+      consensusToleranceSamples: 16 # Maximum lag spread allowed across the alignment windows.
+      recheckIntervalMinutes: 10 # Interval between drift rechecks after startup alignment.
     array: 
       x: [0, 0]
       y: [0, 0]

--- a/src/capture/Capture.cpp
+++ b/src/capture/Capture.cpp
@@ -220,6 +220,7 @@ std::unique_ptr<Source> Capture::factory_source(const std::string& type, c4::yml
     else if (type == VALID_TYPE[3])
     {
       std::vector<double> gain;
+      bool alignmentEnabled = true;
       uint32_t alignmentWindowCount = 3;
       int64_t lagConsensusToleranceSamples = 16;
       uint32_t driftCheckIntervalMinutes = 10;
@@ -233,6 +234,12 @@ std::unique_ptr<Source> Capture::factory_source(const std::string& type, c4::yml
       auto alignmentNode = config["alignment"];
       if (alignmentNode.valid())
       {
+        auto alignmentEnabledNode = alignmentNode["enabled"];
+        if (alignmentEnabledNode.valid())
+        {
+          alignmentEnabledNode >> alignmentEnabled;
+        }
+
         auto alignmentWindowCountNode = alignmentNode["windowCount"];
         if (alignmentWindowCountNode.valid())
         {
@@ -253,6 +260,7 @@ std::unique_ptr<Source> Capture::factory_source(const std::string& type, c4::yml
       }
 
       return std::make_unique<Kraken>(type, fc, fs, path, &saveIq, gain,
+        alignmentEnabled,
         static_cast<size_t>(alignmentWindowCount), lagConsensusToleranceSamples,
         std::chrono::minutes(driftCheckIntervalMinutes));
     }

--- a/src/capture/Capture.cpp
+++ b/src/capture/Capture.cpp
@@ -220,13 +220,41 @@ std::unique_ptr<Source> Capture::factory_source(const std::string& type, c4::yml
     else if (type == VALID_TYPE[3])
     {
       std::vector<double> gain;
+      uint32_t alignmentWindowCount = 3;
+      int64_t lagConsensusToleranceSamples = 16;
+      uint32_t driftCheckIntervalMinutes = 10;
       float _gain;
       for (auto child : config["gain"].children())
       {
         c4::atof(child.val(), &_gain);
         gain.push_back(static_cast<double>(_gain));
       }
-      return std::make_unique<Kraken>(type, fc, fs, path, &saveIq, gain);
+
+      auto alignmentNode = config["alignment"];
+      if (alignmentNode.valid())
+      {
+        auto alignmentWindowCountNode = alignmentNode["windowCount"];
+        if (alignmentWindowCountNode.valid())
+        {
+          alignmentWindowCountNode >> alignmentWindowCount;
+        }
+
+        auto consensusToleranceNode = alignmentNode["consensusToleranceSamples"];
+        if (consensusToleranceNode.valid())
+        {
+          consensusToleranceNode >> lagConsensusToleranceSamples;
+        }
+
+        auto recheckIntervalNode = alignmentNode["recheckIntervalMinutes"];
+        if (recheckIntervalNode.valid())
+        {
+          recheckIntervalNode >> driftCheckIntervalMinutes;
+        }
+      }
+
+      return std::make_unique<Kraken>(type, fc, fs, path, &saveIq, gain,
+        static_cast<size_t>(alignmentWindowCount), lagConsensusToleranceSamples,
+        std::chrono::minutes(driftCheckIntervalMinutes));
     }
     // handle unknown type
     std::cerr << "Error: Source type does not exist." << std::endl;

--- a/src/capture/kraken/Kraken.cpp
+++ b/src/capture/kraken/Kraken.cpp
@@ -3,6 +3,7 @@
 #include <fftw3.h>
 
 #include <algorithm>
+#include <dlfcn.h>
 #include <cmath>
 #include <complex>
 #include <cstdint>
@@ -18,6 +19,137 @@ constexpr size_t kMaxAlignmentWindowSamples = 262144;
 constexpr int64_t kLagConsensusToleranceSamples = 16;
 const std::chrono::minutes kDriftCheckInterval(10);
 const std::chrono::minutes kDriftRetryInterval(1);
+
+using RtlSdrSetDitheringFn = int (*)(rtlsdr_dev_t *, int);
+
+RtlSdrSetDitheringFn lookup_rtlsdr_set_dithering()
+{
+    static RtlSdrSetDitheringFn function = reinterpret_cast<RtlSdrSetDitheringFn>(
+      dlsym(RTLD_DEFAULT, "rtlsdr_set_dithering"));
+    return function;
+}
+
+int set_rtlsdr_dithering_if_supported(rtlsdr_dev_t *device, int enabled)
+{
+    const RtlSdrSetDitheringFn function = lookup_rtlsdr_set_dithering();
+    if (function != nullptr)
+    {
+        return function(device, enabled);
+    }
+
+    static bool warned = false;
+    if (!warned)
+    {
+        std::cout << "[Kraken] Warning: librtlsdr does not expose rtlsdr_set_dithering(); continuing without disabling PLL dithering. In shared-clock RTL-SDR setups this can reduce phase coherence and make startup/drift alignment less stable." << std::endl;
+        warned = true;
+    }
+
+    return 0;
+}
+}
+
+void Kraken::SampleRingBuffer::set_capacity(size_t capacity)
+{
+    data.assign(capacity, std::complex<float>(0.0f, 0.0f));
+    head = 0;
+    length = 0;
+}
+
+void Kraken::SampleRingBuffer::clear()
+{
+    head = 0;
+    length = 0;
+}
+
+size_t Kraken::SampleRingBuffer::size() const
+{
+    return length;
+}
+
+bool Kraken::SampleRingBuffer::empty() const
+{
+    return length == 0;
+}
+
+size_t Kraken::SampleRingBuffer::append(
+    const std::vector<std::complex<float>> &samples)
+{
+    if (data.empty() || samples.empty())
+    {
+        return 0;
+    }
+
+    size_t overwritten = 0;
+    const size_t capacity = data.size();
+    for (size_t i = 0; i < samples.size(); i++)
+    {
+        if (length < capacity)
+        {
+            data[(head + length) % capacity] = samples[i];
+            length++;
+            continue;
+        }
+
+        data[head] = samples[i];
+        head = (head + 1) % capacity;
+        overwritten++;
+    }
+
+    return overwritten;
+}
+
+size_t Kraken::SampleRingBuffer::discard_front(size_t count)
+{
+    const size_t discarded = std::min(count, length);
+    if (discarded == 0)
+    {
+        return 0;
+    }
+
+    head = (head + discarded) % data.size();
+    length -= discarded;
+    return discarded;
+}
+
+bool Kraken::SampleRingBuffer::copy_tail(std::vector<std::complex<float>> *out,
+    size_t count) const
+{
+    if (out == nullptr || count > length)
+    {
+        return false;
+    }
+
+    out->clear();
+    out->reserve(count);
+    const size_t capacity = data.size();
+    const size_t start = (head + length - count) % capacity;
+    for (size_t i = 0; i < count; i++)
+    {
+        out->push_back(data[(start + i) % capacity]);
+    }
+    return true;
+}
+
+size_t Kraken::SampleRingBuffer::pop_front_into(
+    std::vector<std::complex<float>> *out, size_t count)
+{
+    if (out == nullptr)
+    {
+        return 0;
+    }
+
+    const size_t nSamples = std::min(count, length);
+    out->clear();
+    out->reserve(nSamples);
+    const size_t capacity = data.size();
+    for (size_t i = 0; i < nSamples; i++)
+    {
+        out->push_back(data[(head + i) % capacity]);
+    }
+
+    head = (head + nSamples) % capacity;
+    length -= nSamples;
+    return nSamples;
 }
 
 // constructor
@@ -54,9 +186,9 @@ Kraken::Kraken(std::string _type, uint32_t _fc, uint32_t _fs,
         auto it = std::lower_bound(validGains.begin(),
             validGains.end(), adjustedGain);
         if (it != validGains.end()) {
-            gain.push_back(*it);
+            gain[i] = *it;
         } else {
-            gain.push_back(validGains.back());
+            gain[i] = validGains.back();
         }
         std::cout << "[Kraken] Gain update on channel " << i << " from " <<
             adjustedGain << " to " << gain[i] << "." << std::endl;
@@ -77,7 +209,7 @@ void Kraken::start()
         check_status(status, "Failed to set center frequency.");
         status = rtlsdr_set_sample_rate(devs[i], fs);
         check_status(status, "Failed to set sample rate.");
-        status = rtlsdr_set_dithering(devs[i], 0); // disable dither
+        status = set_rtlsdr_dithering_if_supported(devs[i], 0); // disable dither when supported
         check_status(status, "Failed to disable dithering.");
         status = rtlsdr_set_tuner_gain_mode(devs[i], 1); // disable AGC
         check_status(status, "Failed to disable AGC.");
@@ -104,10 +236,6 @@ void Kraken::process(IqData *buffer1, IqData *buffer2)
         std::lock_guard<std::mutex> lock(alignmentMutex);
         outputBuffers[0] = buffer1;
         outputBuffers[1] = buffer2;
-        pendingOutputSamples[0].clear();
-        pendingOutputSamples[1].clear();
-        historySamples[0].clear();
-        historySamples[1].clear();
         scheduledAlignmentDrops[0] = 0;
         scheduledAlignmentDrops[1] = 0;
         appliedAlignmentDrops[0] = 0;
@@ -121,6 +249,13 @@ void Kraken::process(IqData *buffer1, IqData *buffer2)
         alignmentWindowSamples = std::min(kMaxAlignmentWindowSamples,
             std::max(kMinAlignmentWindowSamples, requestedWindow));
         historyCapacitySamples = kStartupAlignmentAttempts * alignmentWindowSamples;
+        pendingOutputCapacitySamples = std::min(static_cast<size_t>(maxPendingBlah2PairedIqSamples),
+            historyCapacitySamples + kEmitChunkSamples);
+        for (size_t i = 0; i < nActiveChannels; i++)
+        {
+            pendingOutputSamples[i].set_capacity(pendingOutputCapacitySamples);
+            historySamples[i].set_capacity(historyCapacitySamples);
+        }
         nextDriftCheckTime = std::chrono::steady_clock::now() + kDriftCheckInterval;
     }
 
@@ -170,20 +305,23 @@ void Kraken::append_input_samples(size_t channelIndex, const int8_t *samples,
         return;
     }
 
-    std::lock_guard<std::mutex> lock(alignmentMutex);
-    std::deque<std::complex<float>> &pending = pendingOutputSamples[channelIndex];
-    std::deque<std::complex<float>> &history = historySamples[channelIndex];
+    thread_local std::vector<std::complex<float>> scratchSamples;
+    scratchSamples.resize(nComplexSamples);
     for (size_t i = 0; i < nComplexSamples; i++)
     {
-        const std::complex<float> sample(static_cast<float>(samples[2 * i]),
-          static_cast<float>(samples[2 * i + 1]));
-        pending.push_back(sample);
-        history.push_back(sample);
+        scratchSamples[i] = {static_cast<float>(samples[2 * i]),
+          static_cast<float>(samples[2 * i + 1])};
     }
 
-    while (history.size() > historyCapacitySamples)
+    std::lock_guard<std::mutex> lock(alignmentMutex);
+    const size_t overwrittenPending = pendingOutputSamples[channelIndex].append(scratchSamples);
+    historySamples[channelIndex].append(scratchSamples);
+    if (overwrittenPending > 0)
     {
-        history.pop_front();
+        const size_t accountedDrops = std::min<size_t>(overwrittenPending,
+          static_cast<size_t>(scheduledAlignmentDrops[channelIndex]));
+        scheduledAlignmentDrops[channelIndex] -= static_cast<uint64_t>(accountedDrops);
+        appliedAlignmentDrops[channelIndex] += static_cast<uint64_t>(accountedDrops);
     }
 
     alignmentCv.notify_all();
@@ -307,15 +445,10 @@ void Kraken::drain_scheduled_drops_locked()
 {
     for (size_t i = 0; i < nActiveChannels; i++)
     {
-        uint64_t nDropped = std::min<uint64_t>(scheduledAlignmentDrops[i],
-          static_cast<uint64_t>(pendingOutputSamples[i].size()));
-        while (nDropped > 0)
-        {
-            pendingOutputSamples[i].pop_front();
-            scheduledAlignmentDrops[i]--;
-            appliedAlignmentDrops[i]++;
-            nDropped--;
-        }
+                const size_t nDropped = pendingOutputSamples[i].discard_front(
+                    static_cast<size_t>(scheduledAlignmentDrops[i]));
+                scheduledAlignmentDrops[i] -= static_cast<uint64_t>(nDropped);
+                appliedAlignmentDrops[i] += static_cast<uint64_t>(nDropped);
     }
 }
 
@@ -351,12 +484,9 @@ bool Kraken::snapshot_recent_history_locked(LagSnapshot *snapshot) const
 
     for (size_t i = 0; i < nActiveChannels; i++)
     {
-        snapshot->channels[i].clear();
-        snapshot->channels[i].reserve(requiredSamples);
-        const size_t startIndex = historySamples[i].size() - requiredSamples;
-        for (size_t sampleIndex = startIndex; sampleIndex < historySamples[i].size(); sampleIndex++)
+        if (!historySamples[i].copy_tail(&snapshot->channels[i], requiredSamples))
         {
-            snapshot->channels[i].push_back(historySamples[i][sampleIndex]);
+            return false;
         }
     }
 
@@ -525,15 +655,8 @@ void Kraken::extract_output_chunk_locked(
         return;
     }
 
-    referenceChunk.reserve(nEmit);
-    surveillanceChunk.reserve(nEmit);
-    for (size_t i = 0; i < nEmit; i++)
-    {
-        referenceChunk.push_back(pendingOutputSamples[0].front());
-        pendingOutputSamples[0].pop_front();
-        surveillanceChunk.push_back(pendingOutputSamples[1].front());
-        pendingOutputSamples[1].pop_front();
-    }
+    pendingOutputSamples[0].pop_front_into(&referenceChunk, nEmit);
+    pendingOutputSamples[1].pop_front_into(&surveillanceChunk, nEmit);
 }
 
 void Kraken::emit_output_chunk(

--- a/src/capture/kraken/Kraken.cpp
+++ b/src/capture/kraken/Kraken.cpp
@@ -258,6 +258,7 @@ void Kraken::stop()
 void Kraken::process(IqData *buffer1, IqData *buffer2)
 {
     RuntimeMetricSnapshot initialMetric;
+    size_t requiredHistorySamples = 0;
     {
         std::lock_guard<std::mutex> lock(alignmentMutex);
         outputBuffers[0] = buffer1;
@@ -280,6 +281,7 @@ void Kraken::process(IqData *buffer1, IqData *buffer2)
         historyCapacitySamples = alignmentWindowCount * alignmentWindowSamples;
         pendingOutputCapacitySamples = std::min(static_cast<size_t>(maxPendingBlah2PairedIqSamples),
             historyCapacitySamples + kEmitChunkSamples);
+        requiredHistorySamples = alignmentWindowCount * alignmentWindowSamples;
         for (size_t i = 0; i < nActiveChannels; i++)
         {
             pendingOutputSamples[i].set_capacity(pendingOutputCapacitySamples);
@@ -291,6 +293,11 @@ void Kraken::process(IqData *buffer1, IqData *buffer2)
 
     write_runtime_metric(initialMetric);
 
+        std::cout << "[Kraken] Startup alignment configured for "
+            << alignmentWindowCount << " windows x " << alignmentWindowSamples
+            << " samples; waiting for " << requiredHistorySamples
+            << " samples per channel before first lag estimate." << std::endl;
+        std::cout << "[Kraken] Starting alignment worker thread." << std::endl;
     std::thread alignmentThread(&Kraken::alignment_worker, this);
     std::vector<std::thread> threads;
     callbackContexts[0].device = this;
@@ -299,8 +306,18 @@ void Kraken::process(IqData *buffer1, IqData *buffer2)
     callbackContexts[1].device = this;
     callbackContexts[1].buffer = buffer2;
     callbackContexts[1].channelIndex = 1;
-    threads.emplace_back(rtlsdr_read_async, devs[0], callback, &callbackContexts[0], 0, 16 * 16384);
-    threads.emplace_back(rtlsdr_read_async, devs[1], callback, &callbackContexts[1], 0, 16 * 16384);
+        std::cout << "[Kraken] Starting async readers on both channels." << std::endl;
+        const auto launch_async_reader = [this](size_t channel, CallbackContext *context)
+        {
+                std::cout << "[Kraken] Async read loop entering on channel "
+                    << channel << "." << std::endl;
+                const int status = rtlsdr_read_async(devs[channel], callback,
+                    context, 0, 16 * 16384);
+                std::cout << "[Kraken] Async read loop exited on channel " << channel
+                    << " with status " << status << "." << std::endl;
+        };
+        threads.emplace_back(launch_async_reader, 0, &callbackContexts[0]);
+        threads.emplace_back(launch_async_reader, 1, &callbackContexts[1]);
     // join threads
     for (auto& thread : threads) {
         thread.join();
@@ -346,8 +363,16 @@ void Kraken::append_input_samples(size_t channelIndex, const int8_t *samples,
     }
 
     std::lock_guard<std::mutex> lock(alignmentMutex);
+        const bool firstCallbackForChannel = pendingOutputSamples[channelIndex].empty()
+            && historySamples[channelIndex].empty();
     const size_t overwrittenPending = pendingOutputSamples[channelIndex].append(scratchSamples);
     historySamples[channelIndex].append(scratchSamples);
+        if (firstCallbackForChannel)
+        {
+                std::cout << "[Kraken] Received first callback block on channel "
+                    << channelIndex << " with " << nComplexSamples
+                    << " IQ samples." << std::endl;
+        }
     if (overwrittenPending > 0)
     {
         const size_t accountedDrops = std::min<size_t>(overwrittenPending,
@@ -362,6 +387,12 @@ void Kraken::append_input_samples(size_t channelIndex, const int8_t *samples,
 
 void Kraken::alignment_worker()
 {
+    bool startupHistoryReadyLogged = false;
+    bool firstAlignedChunkLogged = false;
+    uint64_t startupInvalidMeasurementCount = 0;
+    auto nextStartupProgressLogTime = std::chrono::steady_clock::now();
+    auto nextStartupInvalidLogTime = nextStartupProgressLogTime;
+
     while (true)
     {
         LagSnapshot snapshot;
@@ -387,6 +418,22 @@ void Kraken::alignment_worker()
                 writeRuntimeMetric = true;
             }
 
+                        if (!alignmentReady)
+                        {
+                                const size_t requiredSamples = alignmentWindowCount * alignmentWindowSamples;
+                                const auto now = std::chrono::steady_clock::now();
+                                if ((historySamples[0].size() < requiredSamples
+                                    || historySamples[1].size() < requiredSamples)
+                                    && now >= nextStartupProgressLogTime)
+                                {
+                                        std::cout << "[Kraken] Waiting for startup alignment history: channel 0 has "
+                                            << historySamples[0].size() << "/" << requiredSamples
+                                            << " samples, channel 1 has " << historySamples[1].size()
+                                            << "/" << requiredSamples << "." << std::endl;
+                                        nextStartupProgressLogTime = now + std::chrono::seconds(1);
+                                }
+                        }
+
             if (stopRequested && !alignmentReady)
             {
                 pendingOutputSamples[0].clear();
@@ -400,6 +447,11 @@ void Kraken::alignment_worker()
             {
                 if (!alignmentReady)
                 {
+                    if (!startupHistoryReadyLogged)
+                    {
+                        std::cout << "[Kraken] Collected enough startup history; beginning lag measurement." << std::endl;
+                        startupHistoryReadyLogged = true;
+                    }
                     measureLag = true;
                 }
                 else if (std::chrono::steady_clock::now() >= nextDriftCheckTime)
@@ -438,6 +490,18 @@ void Kraken::alignment_worker()
                     {
                         std::cout << "[Kraken] Drift recheck could not establish a stable lag estimate; retrying in 1 minute." << std::endl;
                         nextDriftCheckTime = std::chrono::steady_clock::now() + kDriftRetryInterval;
+                    }
+                    else
+                    {
+                        startupInvalidMeasurementCount++;
+                        const auto now = std::chrono::steady_clock::now();
+                        if (now >= nextStartupInvalidLogTime)
+                        {
+                            std::cout << "[Kraken] Startup alignment attempt "
+                              << startupInvalidMeasurementCount
+                              << " did not produce a stable lag estimate yet; waiting for more IQ history." << std::endl;
+                            nextStartupInvalidLogTime = now + std::chrono::seconds(1);
+                        }
                     }
                     stopAfterMeasurement = true;
                 }
@@ -510,6 +574,12 @@ void Kraken::alignment_worker()
 
         if (!referenceChunk.empty())
         {
+            if (!firstAlignedChunkLogged)
+            {
+                std::cout << "[Kraken] First aligned output chunk ready with "
+                  << referenceChunk.size() << " IQ samples per channel." << std::endl;
+                firstAlignedChunkLogged = true;
+            }
             emit_output_chunk(referenceChunk, surveillanceChunk);
         }
     }
@@ -534,14 +604,29 @@ void Kraken::schedule_alignment_delta_locked(int64_t deltaSamples)
 {
     if (deltaSamples > 0)
     {
+                std::cout << "[Kraken] Scheduling alignment correction: drop "
+                    << deltaSamples << " samples from channel 0." << std::endl;
         scheduledAlignmentDrops[0] += static_cast<uint64_t>(deltaSamples);
     }
     else if (deltaSamples < 0)
     {
+                std::cout << "[Kraken] Scheduling alignment correction: drop "
+                    << -deltaSamples << " samples from channel 1." << std::endl;
         scheduledAlignmentDrops[1] += static_cast<uint64_t>(-deltaSamples);
     }
 
     drain_scheduled_drops_locked();
+
+        if (scheduledAlignmentDrops[0] > 0)
+        {
+                std::cout << "[Kraken] Waiting to apply remaining correction of "
+                    << scheduledAlignmentDrops[0] << " samples on channel 0 as more IQ arrives." << std::endl;
+        }
+        if (scheduledAlignmentDrops[1] > 0)
+        {
+                std::cout << "[Kraken] Waiting to apply remaining correction of "
+                    << scheduledAlignmentDrops[1] << " samples on channel 1 as more IQ arrives." << std::endl;
+        }
 }
 
 bool Kraken::snapshot_recent_history_locked(LagSnapshot *snapshot) const

--- a/src/capture/kraken/Kraken.cpp
+++ b/src/capture/kraken/Kraken.cpp
@@ -163,20 +163,20 @@ Kraken::Kraken(std::string _type, uint32_t _fc, uint32_t _fs,
         gain.push_back(static_cast<int>(_gain[i]*10));
         channelIndex.push_back(i);
     }
-    std::vector<rtlsdr_dev_t*> devs(channelIndex.size());
+    std::vector<rtlsdr_dev_t*> gainProbeDevs(channelIndex.size());
 
     // store all valid gains
     std::vector<int> validGains;
     int nGains, status;
-    status = rtlsdr_open(&devs[0], 0);
+    status = rtlsdr_open(&gainProbeDevs[0], 0);
     check_status(status, "Failed to open device for available gains.");
-    nGains = rtlsdr_get_tuner_gains(devs[0], nullptr);
+    nGains = rtlsdr_get_tuner_gains(gainProbeDevs[0], nullptr);
     check_status(nGains, "Failed to get number of gains.");
     std::unique_ptr<int[]> _validGains(new int[nGains]);
-    status = rtlsdr_get_tuner_gains(devs[0], _validGains.get());
+    status = rtlsdr_get_tuner_gains(gainProbeDevs[0], _validGains.get());
     check_status(status, "Failed to get number of gains.");
     validGains.assign(_validGains.get(), _validGains.get() + nGains);
-    status = rtlsdr_close(devs[0]);
+    status = rtlsdr_close(gainProbeDevs[0]);
     check_status(status, "Failed to close device for available gains.");
 
     // update gains to next value if invalid

--- a/src/capture/kraken/Kraken.cpp
+++ b/src/capture/kraken/Kraken.cpp
@@ -155,23 +155,25 @@ size_t Kraken::SampleRingBuffer::pop_front_into(
 // constructor
 Kraken::Kraken(std::string _type, uint32_t _fc, uint32_t _fs,
     std::string _path, std::atomic<bool> *_saveIq, std::vector<double> _gain,
+    bool _alignmentEnabled,
     size_t _alignmentWindowCount, int64_t _lagConsensusToleranceSamples,
     std::chrono::minutes _driftCheckInterval)
     : Source(_type, _fc, _fs, _path, _saveIq)
 {
-    if (_alignmentWindowCount == 0)
+    if (_alignmentEnabled && _alignmentWindowCount == 0)
     {
         throw std::invalid_argument("[Kraken] capture.device.alignment.windowCount must be at least 1.");
     }
-    if (_lagConsensusToleranceSamples < 0)
+    if (_alignmentEnabled && _lagConsensusToleranceSamples < 0)
     {
         throw std::invalid_argument("[Kraken] capture.device.alignment.consensusToleranceSamples must be non-negative.");
     }
-    if (_driftCheckInterval.count() <= 0)
+    if (_alignmentEnabled && _driftCheckInterval.count() <= 0)
     {
         throw std::invalid_argument("[Kraken] capture.device.alignment.recheckIntervalMinutes must be greater than 0.");
     }
 
+    alignmentEnabled = _alignmentEnabled;
     alignmentWindowCount = _alignmentWindowCount;
     lagConsensusToleranceSamples = _lagConsensusToleranceSamples;
     driftCheckInterval = _driftCheckInterval;
@@ -268,7 +270,7 @@ void Kraken::process(IqData *buffer1, IqData *buffer2)
         appliedAlignmentDrops[0] = 0;
         appliedAlignmentDrops[1] = 0;
         stopRequested = false;
-        alignmentReady = false;
+        alignmentReady = !alignmentEnabled;
         initialLagSamples = 0;
         lastMeasuredRawLagSamples = 0;
         rawLagValid = false;
@@ -293,11 +295,18 @@ void Kraken::process(IqData *buffer1, IqData *buffer2)
 
     write_runtime_metric(initialMetric);
 
+    if (alignmentEnabled)
+    {
         std::cout << "[Kraken] Startup alignment configured for "
             << alignmentWindowCount << " windows x " << alignmentWindowSamples
             << " samples; waiting for " << requiredHistorySamples
             << " samples per channel before first lag estimate." << std::endl;
-        std::cout << "[Kraken] Starting alignment worker thread." << std::endl;
+    }
+    else
+    {
+        std::cout << "[Kraken] Startup alignment disabled; forwarding channels without startup or drift correction." << std::endl;
+    }
+    std::cout << "[Kraken] Starting alignment worker thread." << std::endl;
     std::thread alignmentThread(&Kraken::alignment_worker, this);
     std::vector<std::thread> threads;
     callbackContexts[0].device = this;
@@ -441,7 +450,8 @@ void Kraken::alignment_worker()
                 break;
             }
 
-            if (snapshot_recent_history_locked(&snapshot)
+                        if (alignmentEnabled
+                            && snapshot_recent_history_locked(&snapshot)
               && scheduledAlignmentDrops[0] == 0
               && scheduledAlignmentDrops[1] == 0)
             {

--- a/src/capture/kraken/Kraken.cpp
+++ b/src/capture/kraken/Kraken.cpp
@@ -371,7 +371,7 @@ void Kraken::append_input_samples(size_t channelIndex, const int8_t *samples,
           static_cast<float>(samples[2 * i + 1])};
     }
 
-    std::lock_guard<std::mutex> lock(alignmentMutex);
+        std::lock_guard<std::mutex> lock(alignmentMutex);
         const bool firstCallbackForChannel = pendingOutputSamples[channelIndex].empty()
             && historySamples[channelIndex].empty();
     const size_t overwrittenPending = pendingOutputSamples[channelIndex].append(scratchSamples);
@@ -427,21 +427,21 @@ void Kraken::alignment_worker()
                 writeRuntimeMetric = true;
             }
 
-                        if (!alignmentReady)
-                        {
-                                const size_t requiredSamples = alignmentWindowCount * alignmentWindowSamples;
-                                const auto now = std::chrono::steady_clock::now();
-                                if ((historySamples[0].size() < requiredSamples
-                                    || historySamples[1].size() < requiredSamples)
-                                    && now >= nextStartupProgressLogTime)
-                                {
-                                        std::cout << "[Kraken] Waiting for startup alignment history: channel 0 has "
-                                            << historySamples[0].size() << "/" << requiredSamples
-                                            << " samples, channel 1 has " << historySamples[1].size()
-                                            << "/" << requiredSamples << "." << std::endl;
-                                        nextStartupProgressLogTime = now + std::chrono::seconds(1);
-                                }
-                        }
+            if (!alignmentReady)
+            {
+                const size_t requiredSamples = alignmentWindowCount * alignmentWindowSamples;
+                const auto now = std::chrono::steady_clock::now();
+                if ((historySamples[0].size() < requiredSamples
+                  || historySamples[1].size() < requiredSamples)
+                  && now >= nextStartupProgressLogTime)
+                {
+                    std::cout << "[Kraken] Waiting for startup alignment history: channel 0 has "
+                      << historySamples[0].size() << "/" << requiredSamples
+                      << " samples, channel 1 has " << historySamples[1].size()
+                      << "/" << requiredSamples << "." << std::endl;
+                    nextStartupProgressLogTime = now + std::chrono::seconds(1);
+                }
+            }
 
             if (stopRequested && !alignmentReady)
             {
@@ -614,29 +614,29 @@ void Kraken::schedule_alignment_delta_locked(int64_t deltaSamples)
 {
     if (deltaSamples > 0)
     {
-                std::cout << "[Kraken] Scheduling alignment correction: drop "
-                    << deltaSamples << " samples from channel 0." << std::endl;
+        std::cout << "[Kraken] Scheduling alignment correction: drop "
+          << deltaSamples << " samples from channel 0." << std::endl;
         scheduledAlignmentDrops[0] += static_cast<uint64_t>(deltaSamples);
     }
     else if (deltaSamples < 0)
     {
-                std::cout << "[Kraken] Scheduling alignment correction: drop "
-                    << -deltaSamples << " samples from channel 1." << std::endl;
+        std::cout << "[Kraken] Scheduling alignment correction: drop "
+          << -deltaSamples << " samples from channel 1." << std::endl;
         scheduledAlignmentDrops[1] += static_cast<uint64_t>(-deltaSamples);
     }
 
     drain_scheduled_drops_locked();
 
-        if (scheduledAlignmentDrops[0] > 0)
-        {
-                std::cout << "[Kraken] Waiting to apply remaining correction of "
-                    << scheduledAlignmentDrops[0] << " samples on channel 0 as more IQ arrives." << std::endl;
-        }
-        if (scheduledAlignmentDrops[1] > 0)
-        {
-                std::cout << "[Kraken] Waiting to apply remaining correction of "
-                    << scheduledAlignmentDrops[1] << " samples on channel 1 as more IQ arrives." << std::endl;
-        }
+    if (scheduledAlignmentDrops[0] > 0)
+    {
+        std::cout << "[Kraken] Waiting to apply remaining correction of "
+          << scheduledAlignmentDrops[0] << " samples on channel 0 as more IQ arrives." << std::endl;
+    }
+    if (scheduledAlignmentDrops[1] > 0)
+    {
+        std::cout << "[Kraken] Waiting to apply remaining correction of "
+          << scheduledAlignmentDrops[1] << " samples on channel 1 as more IQ arrives." << std::endl;
+    }
 }
 
 bool Kraken::snapshot_recent_history_locked(LagSnapshot *snapshot) const

--- a/src/capture/kraken/Kraken.cpp
+++ b/src/capture/kraken/Kraken.cpp
@@ -7,17 +7,17 @@
 #include <cmath>
 #include <complex>
 #include <cstdint>
+#include <fstream>
 #include <iostream>
+#include <sstream>
+#include <stdexcept>
 #include <thread>
 
 namespace
 {
-constexpr size_t kStartupAlignmentAttempts = 3;
 constexpr size_t kEmitChunkSamples = 16384;
 constexpr size_t kMinAlignmentWindowSamples = 65536;
 constexpr size_t kMaxAlignmentWindowSamples = 262144;
-constexpr int64_t kLagConsensusToleranceSamples = 16;
-const std::chrono::minutes kDriftCheckInterval(10);
 const std::chrono::minutes kDriftRetryInterval(1);
 
 using RtlSdrSetDitheringFn = int (*)(rtlsdr_dev_t *, int);
@@ -154,9 +154,34 @@ size_t Kraken::SampleRingBuffer::pop_front_into(
 
 // constructor
 Kraken::Kraken(std::string _type, uint32_t _fc, uint32_t _fs,
-    std::string _path, std::atomic<bool> *_saveIq, std::vector<double> _gain)
+    std::string _path, std::atomic<bool> *_saveIq, std::vector<double> _gain,
+    size_t _alignmentWindowCount, int64_t _lagConsensusToleranceSamples,
+    std::chrono::minutes _driftCheckInterval)
     : Source(_type, _fc, _fs, _path, _saveIq)
 {
+    if (_alignmentWindowCount == 0)
+    {
+        throw std::invalid_argument("[Kraken] capture.device.alignment.windowCount must be at least 1.");
+    }
+    if (_lagConsensusToleranceSamples < 0)
+    {
+        throw std::invalid_argument("[Kraken] capture.device.alignment.consensusToleranceSamples must be non-negative.");
+    }
+    if (_driftCheckInterval.count() <= 0)
+    {
+        throw std::invalid_argument("[Kraken] capture.device.alignment.recheckIntervalMinutes must be greater than 0.");
+    }
+
+    alignmentWindowCount = _alignmentWindowCount;
+    lagConsensusToleranceSamples = _lagConsensusToleranceSamples;
+    driftCheckInterval = _driftCheckInterval;
+    runtimeMetricPath = path;
+    if (!runtimeMetricPath.empty() && runtimeMetricPath.back() != '/')
+    {
+        runtimeMetricPath += "/";
+    }
+    runtimeMetricPath += "kraken-alignment-runtime.json";
+
     // convert gain to tenths of dB
     for (size_t i = 0; i < _gain.size(); i++)
     {
@@ -232,6 +257,7 @@ void Kraken::stop()
 
 void Kraken::process(IqData *buffer1, IqData *buffer2)
 {
+    RuntimeMetricSnapshot initialMetric;
     {
         std::lock_guard<std::mutex> lock(alignmentMutex);
         outputBuffers[0] = buffer1;
@@ -243,12 +269,15 @@ void Kraken::process(IqData *buffer1, IqData *buffer2)
         stopRequested = false;
         alignmentReady = false;
         initialLagSamples = 0;
+        lastMeasuredRawLagSamples = 0;
+        rawLagValid = false;
+        runtimeMetricDirty = false;
         const size_t callbackBlockSamples = 16 * 16384 / 2;
         const size_t requestedWindow = next_power_of_two(std::max(
             callbackBlockSamples, static_cast<size_t>(std::max<uint32_t>(fs / 10, 1))));
         alignmentWindowSamples = std::min(kMaxAlignmentWindowSamples,
             std::max(kMinAlignmentWindowSamples, requestedWindow));
-        historyCapacitySamples = kStartupAlignmentAttempts * alignmentWindowSamples;
+        historyCapacitySamples = alignmentWindowCount * alignmentWindowSamples;
         pendingOutputCapacitySamples = std::min(static_cast<size_t>(maxPendingBlah2PairedIqSamples),
             historyCapacitySamples + kEmitChunkSamples);
         for (size_t i = 0; i < nActiveChannels; i++)
@@ -256,8 +285,11 @@ void Kraken::process(IqData *buffer1, IqData *buffer2)
             pendingOutputSamples[i].set_capacity(pendingOutputCapacitySamples);
             historySamples[i].set_capacity(historyCapacitySamples);
         }
-        nextDriftCheckTime = std::chrono::steady_clock::now() + kDriftCheckInterval;
+        nextDriftCheckTime = std::chrono::steady_clock::now() + driftCheckInterval;
+        initialMetric = snapshot_runtime_metric_locked();
     }
+
+    write_runtime_metric(initialMetric);
 
     std::thread alignmentThread(&Kraken::alignment_worker, this);
     std::vector<std::thread> threads;
@@ -322,6 +354,7 @@ void Kraken::append_input_samples(size_t channelIndex, const int8_t *samples,
           static_cast<size_t>(scheduledAlignmentDrops[channelIndex]));
         scheduledAlignmentDrops[channelIndex] -= static_cast<uint64_t>(accountedDrops);
         appliedAlignmentDrops[channelIndex] += static_cast<uint64_t>(accountedDrops);
+        runtimeMetricDirty = true;
     }
 
     alignmentCv.notify_all();
@@ -332,7 +365,9 @@ void Kraken::alignment_worker()
     while (true)
     {
         LagSnapshot snapshot;
+        RuntimeMetricSnapshot runtimeMetricSnapshot;
         bool measureLag = false;
+        bool writeRuntimeMetric = false;
         std::vector<std::complex<float>> referenceChunk;
         std::vector<std::complex<float>> surveillanceChunk;
 
@@ -345,6 +380,12 @@ void Kraken::alignment_worker()
             });
 
             drain_scheduled_drops_locked();
+            if (runtimeMetricDirty)
+            {
+                runtimeMetricSnapshot = snapshot_runtime_metric_locked();
+                runtimeMetricDirty = false;
+                writeRuntimeMetric = true;
+            }
 
             if (stopRequested && !alignmentReady)
             {
@@ -381,55 +422,80 @@ void Kraken::alignment_worker()
             }
         }
 
+        if (writeRuntimeMetric)
+        {
+            write_runtime_metric(runtimeMetricSnapshot);
+        }
+
         if (measureLag)
         {
             const LagMeasurement measurement = measure_snapshot_lag(snapshot);
-            std::lock_guard<std::mutex> lock(alignmentMutex);
-            if (stopRequested)
             {
-                continue;
-            }
-
-            if (!measurement.valid)
-            {
-                if (alignmentReady)
+                std::lock_guard<std::mutex> lock(alignmentMutex);
+                if (stopRequested)
                 {
-                    std::cout << "[Kraken] Drift recheck could not establish a stable lag estimate; retrying in 1 minute." << std::endl;
-                    nextDriftCheckTime = std::chrono::steady_clock::now() + kDriftRetryInterval;
+                    continue;
                 }
-                continue;
+
+                if (!measurement.valid)
+                {
+                    if (alignmentReady)
+                    {
+                        std::cout << "[Kraken] Drift recheck could not establish a stable lag estimate; retrying in 1 minute." << std::endl;
+                        nextDriftCheckTime = std::chrono::steady_clock::now() + kDriftRetryInterval;
+                    }
+                    continue;
+                }
+
+                lastMeasuredRawLagSamples = measurement.lagSamples;
+                rawLagValid = true;
+
+                const int64_t currentCorrection = static_cast<int64_t>(appliedAlignmentDrops[0])
+                  - static_cast<int64_t>(appliedAlignmentDrops[1]);
+                const int64_t correctionDelta = measurement.lagSamples - currentCorrection;
+
+                if (!alignmentReady)
+                {
+                    initialLagSamples = measurement.lagSamples;
+                    schedule_alignment_delta_locked(correctionDelta);
+                    alignmentReady = true;
+                    nextDriftCheckTime = std::chrono::steady_clock::now() + driftCheckInterval;
+                    runtimeMetricDirty = true;
+                    runtimeMetricSnapshot = snapshot_runtime_metric_locked();
+                    runtimeMetricDirty = false;
+                    writeRuntimeMetric = true;
+                    std::cout << "[Kraken] Startup sample-time alignment established at "
+                      << measurement.lagSamples << " samples ("
+                      << lag_samples_to_microseconds(measurement.lagSamples)
+                      << " us)." << std::endl;
+                    alignmentCv.notify_all();
+                }
+                else
+                {
+                    nextDriftCheckTime = std::chrono::steady_clock::now() + driftCheckInterval;
+                    runtimeMetricDirty = true;
+                    if (correctionDelta != 0)
+                    {
+                        const int64_t driftFromInitial = measurement.lagSamples - initialLagSamples;
+                        schedule_alignment_delta_locked(correctionDelta);
+                        std::cout << "[Kraken] Sample-time drift detected: current difference "
+                          << measurement.lagSamples << " samples ("
+                          << lag_samples_to_microseconds(measurement.lagSamples)
+                          << " us), drift from initial " << driftFromInitial
+                          << " samples (" << lag_samples_to_microseconds(driftFromInitial)
+                          << " us)." << std::endl;
+                        alignmentCv.notify_all();
+                    }
+
+                    runtimeMetricSnapshot = snapshot_runtime_metric_locked();
+                    runtimeMetricDirty = false;
+                    writeRuntimeMetric = true;
+                }
             }
 
-            const int64_t currentCorrection = static_cast<int64_t>(appliedAlignmentDrops[0])
-              - static_cast<int64_t>(appliedAlignmentDrops[1]);
-            const int64_t correctionDelta = measurement.lagSamples - currentCorrection;
-
-            if (!alignmentReady)
+            if (writeRuntimeMetric)
             {
-                initialLagSamples = measurement.lagSamples;
-                schedule_alignment_delta_locked(correctionDelta);
-                alignmentReady = true;
-                nextDriftCheckTime = std::chrono::steady_clock::now() + kDriftCheckInterval;
-                std::cout << "[Kraken] Startup sample-time alignment established at "
-                  << measurement.lagSamples << " samples ("
-                  << lag_samples_to_microseconds(measurement.lagSamples)
-                  << " us)." << std::endl;
-                alignmentCv.notify_all();
-                continue;
-            }
-
-            nextDriftCheckTime = std::chrono::steady_clock::now() + kDriftCheckInterval;
-            if (correctionDelta != 0)
-            {
-                const int64_t driftFromInitial = measurement.lagSamples - initialLagSamples;
-                schedule_alignment_delta_locked(correctionDelta);
-                std::cout << "[Kraken] Sample-time drift detected: current difference "
-                  << measurement.lagSamples << " samples ("
-                  << lag_samples_to_microseconds(measurement.lagSamples)
-                  << " us), drift from initial " << driftFromInitial
-                  << " samples (" << lag_samples_to_microseconds(driftFromInitial)
-                  << " us)." << std::endl;
-                alignmentCv.notify_all();
+                write_runtime_metric(runtimeMetricSnapshot);
             }
             continue;
         }
@@ -445,10 +511,14 @@ void Kraken::drain_scheduled_drops_locked()
 {
     for (size_t i = 0; i < nActiveChannels; i++)
     {
-                const size_t nDropped = pendingOutputSamples[i].discard_front(
-                    static_cast<size_t>(scheduledAlignmentDrops[i]));
-                scheduledAlignmentDrops[i] -= static_cast<uint64_t>(nDropped);
-                appliedAlignmentDrops[i] += static_cast<uint64_t>(nDropped);
+        const size_t nDropped = pendingOutputSamples[i].discard_front(
+          static_cast<size_t>(scheduledAlignmentDrops[i]));
+        scheduledAlignmentDrops[i] -= static_cast<uint64_t>(nDropped);
+        appliedAlignmentDrops[i] += static_cast<uint64_t>(nDropped);
+        if (nDropped > 0)
+        {
+            runtimeMetricDirty = true;
+        }
     }
 }
 
@@ -473,7 +543,7 @@ bool Kraken::snapshot_recent_history_locked(LagSnapshot *snapshot) const
         return false;
     }
 
-    const size_t requiredSamples = kStartupAlignmentAttempts * alignmentWindowSamples;
+    const size_t requiredSamples = alignmentWindowCount * alignmentWindowSamples;
     for (size_t i = 0; i < nActiveChannels; i++)
     {
         if (historySamples[i].size() < requiredSamples)
@@ -496,7 +566,7 @@ bool Kraken::snapshot_recent_history_locked(LagSnapshot *snapshot) const
 Kraken::LagMeasurement Kraken::measure_snapshot_lag(const LagSnapshot &snapshot) const
 {
     LagMeasurement measurement;
-    const size_t requiredSamples = kStartupAlignmentAttempts * alignmentWindowSamples;
+    const size_t requiredSamples = alignmentWindowCount * alignmentWindowSamples;
     if (snapshot.channels[0].size() != requiredSamples
       || snapshot.channels[1].size() != requiredSamples)
     {
@@ -504,10 +574,10 @@ Kraken::LagMeasurement Kraken::measure_snapshot_lag(const LagSnapshot &snapshot)
     }
 
     std::vector<int64_t> lags;
-    lags.reserve(kStartupAlignmentAttempts);
+    lags.reserve(alignmentWindowCount);
     double peakMagnitude = 0.0;
 
-    for (size_t attempt = 0; attempt < kStartupAlignmentAttempts; attempt++)
+    for (size_t attempt = 0; attempt < alignmentWindowCount; attempt++)
     {
         const size_t offset = attempt * alignmentWindowSamples;
         std::vector<std::complex<float>> referenceWindow(
@@ -531,7 +601,7 @@ Kraken::LagMeasurement Kraken::measure_snapshot_lag(const LagSnapshot &snapshot)
     const int64_t medianLag = sortedLags[sortedLags.size() / 2];
     for (size_t i = 0; i < lags.size(); i++)
     {
-        if (std::llabs(lags[i] - medianLag) > kLagConsensusToleranceSamples)
+        if (std::llabs(lags[i] - medianLag) > lagConsensusToleranceSamples)
         {
             return measurement;
         }
@@ -705,6 +775,57 @@ double Kraken::lag_samples_to_microseconds(int64_t lagSamples) const
         return 0.0;
     }
     return static_cast<double>(lagSamples) * 1000000.0 / static_cast<double>(fs);
+}
+
+uint64_t Kraken::current_time_ms()
+{
+    return static_cast<uint64_t>(std::chrono::duration_cast<std::chrono::milliseconds>(
+      std::chrono::system_clock::now().time_since_epoch()).count());
+}
+
+Kraken::RuntimeMetricSnapshot Kraken::snapshot_runtime_metric_locked() const
+{
+    RuntimeMetricSnapshot snapshot;
+    snapshot.alignmentReady = alignmentReady;
+    snapshot.rawLagValid = rawLagValid;
+    snapshot.updatedAtMs = current_time_ms();
+    snapshot.currentRawLagSamples = lastMeasuredRawLagSamples;
+    snapshot.appliedCorrectionSamples = static_cast<int64_t>(appliedAlignmentDrops[0])
+      - static_cast<int64_t>(appliedAlignmentDrops[1]);
+    if (rawLagValid)
+    {
+        snapshot.driftSamples = lastMeasuredRawLagSamples - initialLagSamples;
+    }
+    return snapshot;
+}
+
+void Kraken::write_runtime_metric(const RuntimeMetricSnapshot &snapshot)
+{
+    std::ofstream metricFile(runtimeMetricPath, std::ios::trunc);
+    if (!metricFile.is_open())
+    {
+        if (!runtimeMetricWriteWarned)
+        {
+            std::cerr << "[Kraken] Warning: failed to write alignment runtime metric to "
+              << runtimeMetricPath << std::endl;
+            runtimeMetricWriteWarned = true;
+        }
+        return;
+    }
+
+    std::ostringstream json;
+    json << "{\n"
+         << "  \"timestamp\": " << snapshot.updatedAtMs << ",\n"
+         << "  \"alignmentReady\": " << (snapshot.alignmentReady ? "true" : "false") << ",\n"
+         << "  \"rawLagValid\": " << (snapshot.rawLagValid ? "true" : "false") << ",\n"
+         << "  \"currentRawLagSamples\": " << snapshot.currentRawLagSamples << ",\n"
+         << "  \"currentRawLagUs\": " << lag_samples_to_microseconds(snapshot.currentRawLagSamples) << ",\n"
+         << "  \"appliedCorrectionSamples\": " << snapshot.appliedCorrectionSamples << ",\n"
+         << "  \"appliedCorrectionUs\": " << lag_samples_to_microseconds(snapshot.appliedCorrectionSamples) << ",\n"
+         << "  \"driftSamples\": " << snapshot.driftSamples << ",\n"
+         << "  \"driftUs\": " << lag_samples_to_microseconds(snapshot.driftSamples) << "\n"
+         << "}\n";
+    metricFile << json.str();
 }
 
 void Kraken::replay(IqData *buffer1, IqData *buffer2, std::string _file, bool _loop)

--- a/src/capture/kraken/Kraken.cpp
+++ b/src/capture/kraken/Kraken.cpp
@@ -1,12 +1,27 @@
 #include "Kraken.h"
 
-#include <iostream>
-#include <complex>
-#include <thread>
+#include <fftw3.h>
+
 #include <algorithm>
+#include <cmath>
+#include <complex>
+#include <cstdint>
+#include <iostream>
+#include <thread>
+
+namespace
+{
+constexpr size_t kStartupAlignmentAttempts = 3;
+constexpr size_t kEmitChunkSamples = 16384;
+constexpr size_t kMinAlignmentWindowSamples = 65536;
+constexpr size_t kMaxAlignmentWindowSamples = 262144;
+constexpr int64_t kLagConsensusToleranceSamples = 16;
+const std::chrono::minutes kDriftCheckInterval(10);
+const std::chrono::minutes kDriftRetryInterval(1);
+}
 
 // constructor
-Kraken::Kraken(std::string _type, uint32_t _fc, uint32_t _fs, 
+Kraken::Kraken(std::string _type, uint32_t _fc, uint32_t _fs,
     std::string _path, std::atomic<bool> *_saveIq, std::vector<double> _gain)
     : Source(_type, _fc, _fs, _path, _saveIq)
 {
@@ -36,14 +51,14 @@ Kraken::Kraken(std::string _type, uint32_t _fc, uint32_t _fs,
     for (size_t i = 0; i < _gain.size(); i++)
     {
         int adjustedGain = static_cast<int>(_gain[i] * 10);
-        auto it = std::lower_bound(validGains.begin(), 
+        auto it = std::lower_bound(validGains.begin(),
             validGains.end(), adjustedGain);
         if (it != validGains.end()) {
             gain.push_back(*it);
         } else {
             gain.push_back(validGains.back());
         }
-        std::cout << "[Kraken] Gain update on channel " << i << " from " << 
+        std::cout << "[Kraken] Gain update on channel " << i << " from " <<
             adjustedGain << " to " << gain[i] << "." << std::endl;
     }
 }
@@ -51,7 +66,7 @@ Kraken::Kraken(std::string _type, uint32_t _fc, uint32_t _fs,
 void Kraken::start()
 {
     int status;
-    for (size_t i = 0; i < channelIndex.size(); i++) 
+    for (size_t i = 0; i < channelIndex.size(); i++)
     {
         std::cout << "[Kraken] Setting up channel " << i << "." << std::endl;
 
@@ -76,7 +91,7 @@ void Kraken::start()
 void Kraken::stop()
 {
     int status;
-    for (size_t i = 0; i < channelIndex.size(); i++) 
+    for (size_t i = 0; i < channelIndex.size(); i++)
     {
         status = rtlsdr_cancel_async(devs[i]);
         check_status(status, "Failed to stop async read.");
@@ -85,6 +100,31 @@ void Kraken::stop()
 
 void Kraken::process(IqData *buffer1, IqData *buffer2)
 {
+    {
+        std::lock_guard<std::mutex> lock(alignmentMutex);
+        outputBuffers[0] = buffer1;
+        outputBuffers[1] = buffer2;
+        pendingOutputSamples[0].clear();
+        pendingOutputSamples[1].clear();
+        historySamples[0].clear();
+        historySamples[1].clear();
+        scheduledAlignmentDrops[0] = 0;
+        scheduledAlignmentDrops[1] = 0;
+        appliedAlignmentDrops[0] = 0;
+        appliedAlignmentDrops[1] = 0;
+        stopRequested = false;
+        alignmentReady = false;
+        initialLagSamples = 0;
+        const size_t callbackBlockSamples = 16 * 16384 / 2;
+        const size_t requestedWindow = next_power_of_two(std::max(
+            callbackBlockSamples, static_cast<size_t>(std::max<uint32_t>(fs / 10, 1))));
+        alignmentWindowSamples = std::min(kMaxAlignmentWindowSamples,
+            std::max(kMinAlignmentWindowSamples, requestedWindow));
+        historyCapacitySamples = kStartupAlignmentAttempts * alignmentWindowSamples;
+        nextDriftCheckTime = std::chrono::steady_clock::now() + kDriftCheckInterval;
+    }
+
+    std::thread alignmentThread(&Kraken::alignment_worker, this);
     std::vector<std::thread> threads;
     callbackContexts[0].device = this;
     callbackContexts[0].buffer = buffer1;
@@ -98,33 +138,450 @@ void Kraken::process(IqData *buffer1, IqData *buffer2)
     for (auto& thread : threads) {
         thread.join();
     }
+
+    {
+        std::lock_guard<std::mutex> lock(alignmentMutex);
+        stopRequested = true;
+    }
+    alignmentCv.notify_all();
+    alignmentThread.join();
 }
 
-void Kraken::callback(unsigned char *buf, uint32_t len, void *ctx) 
+void Kraken::callback(unsigned char *buf, uint32_t len, void *ctx)
 {
     CallbackContext *context = static_cast<CallbackContext *>(ctx);
-    IqData *buffer_blah2 = context->buffer;
     int8_t *buffer_kraken = reinterpret_cast<int8_t *>(buf);
 
-    buffer_blah2->lock();
-
-    for (size_t i = 0; i < len; i += 2) {
-        double iqi = static_cast<double>(buffer_kraken[i]);
-        double iqq = static_cast<double>(buffer_kraken[i + 1]);
-
-        buffer_blah2->push_back({iqi, iqq});
-    }
-
-    buffer_blah2->unlock_and_notify();
-
-        context->device->append_save_samples(context->channelIndex, buffer_kraken,
-            static_cast<size_t>(len / 2));
+    context->device->append_input_samples(context->channelIndex, buffer_kraken,
+        static_cast<size_t>(len / 2));
 }
 
 void Kraken::append_save_samples(size_t channelIndex, const int8_t *samples,
     size_t nComplexSamples)
 {
     append_blah2_paired_iq_samples(channelIndex, samples, nComplexSamples);
+}
+
+void Kraken::append_input_samples(size_t channelIndex, const int8_t *samples,
+    size_t nComplexSamples)
+{
+    if (channelIndex >= nActiveChannels || samples == nullptr)
+    {
+        return;
+    }
+
+    std::lock_guard<std::mutex> lock(alignmentMutex);
+    std::deque<std::complex<float>> &pending = pendingOutputSamples[channelIndex];
+    std::deque<std::complex<float>> &history = historySamples[channelIndex];
+    for (size_t i = 0; i < nComplexSamples; i++)
+    {
+        const std::complex<float> sample(static_cast<float>(samples[2 * i]),
+          static_cast<float>(samples[2 * i + 1]));
+        pending.push_back(sample);
+        history.push_back(sample);
+    }
+
+    while (history.size() > historyCapacitySamples)
+    {
+        history.pop_front();
+    }
+
+    alignmentCv.notify_all();
+}
+
+void Kraken::alignment_worker()
+{
+    while (true)
+    {
+        LagSnapshot snapshot;
+        bool measureLag = false;
+        std::vector<std::complex<float>> referenceChunk;
+        std::vector<std::complex<float>> surveillanceChunk;
+
+        {
+            std::unique_lock<std::mutex> lock(alignmentMutex);
+            alignmentCv.wait_for(lock, std::chrono::milliseconds(20), [&]() {
+                return stopRequested
+                    || !pendingOutputSamples[0].empty()
+                    || !pendingOutputSamples[1].empty();
+            });
+
+            drain_scheduled_drops_locked();
+
+            if (stopRequested && !alignmentReady)
+            {
+                pendingOutputSamples[0].clear();
+                pendingOutputSamples[1].clear();
+                break;
+            }
+
+            if (snapshot_recent_history_locked(&snapshot)
+              && scheduledAlignmentDrops[0] == 0
+              && scheduledAlignmentDrops[1] == 0)
+            {
+                if (!alignmentReady)
+                {
+                    measureLag = true;
+                }
+                else if (std::chrono::steady_clock::now() >= nextDriftCheckTime)
+                {
+                    measureLag = true;
+                }
+            }
+
+            if (!measureLag && alignmentReady)
+            {
+                extract_output_chunk_locked(referenceChunk, surveillanceChunk,
+                  kEmitChunkSamples);
+            }
+
+            if (stopRequested && pendingOutputSamples[0].empty()
+              && pendingOutputSamples[1].empty()
+              && referenceChunk.empty() && surveillanceChunk.empty())
+            {
+                break;
+            }
+        }
+
+        if (measureLag)
+        {
+            const LagMeasurement measurement = measure_snapshot_lag(snapshot);
+            std::lock_guard<std::mutex> lock(alignmentMutex);
+            if (stopRequested)
+            {
+                continue;
+            }
+
+            if (!measurement.valid)
+            {
+                if (alignmentReady)
+                {
+                    std::cout << "[Kraken] Drift recheck could not establish a stable lag estimate; retrying in 1 minute." << std::endl;
+                    nextDriftCheckTime = std::chrono::steady_clock::now() + kDriftRetryInterval;
+                }
+                continue;
+            }
+
+            const int64_t currentCorrection = static_cast<int64_t>(appliedAlignmentDrops[0])
+              - static_cast<int64_t>(appliedAlignmentDrops[1]);
+            const int64_t correctionDelta = measurement.lagSamples - currentCorrection;
+
+            if (!alignmentReady)
+            {
+                initialLagSamples = measurement.lagSamples;
+                schedule_alignment_delta_locked(correctionDelta);
+                alignmentReady = true;
+                nextDriftCheckTime = std::chrono::steady_clock::now() + kDriftCheckInterval;
+                std::cout << "[Kraken] Startup sample-time alignment established at "
+                  << measurement.lagSamples << " samples ("
+                  << lag_samples_to_microseconds(measurement.lagSamples)
+                  << " us)." << std::endl;
+                alignmentCv.notify_all();
+                continue;
+            }
+
+            nextDriftCheckTime = std::chrono::steady_clock::now() + kDriftCheckInterval;
+            if (correctionDelta != 0)
+            {
+                const int64_t driftFromInitial = measurement.lagSamples - initialLagSamples;
+                schedule_alignment_delta_locked(correctionDelta);
+                std::cout << "[Kraken] Sample-time drift detected: current difference "
+                  << measurement.lagSamples << " samples ("
+                  << lag_samples_to_microseconds(measurement.lagSamples)
+                  << " us), drift from initial " << driftFromInitial
+                  << " samples (" << lag_samples_to_microseconds(driftFromInitial)
+                  << " us)." << std::endl;
+                alignmentCv.notify_all();
+            }
+            continue;
+        }
+
+        if (!referenceChunk.empty())
+        {
+            emit_output_chunk(referenceChunk, surveillanceChunk);
+        }
+    }
+}
+
+void Kraken::drain_scheduled_drops_locked()
+{
+    for (size_t i = 0; i < nActiveChannels; i++)
+    {
+        uint64_t nDropped = std::min<uint64_t>(scheduledAlignmentDrops[i],
+          static_cast<uint64_t>(pendingOutputSamples[i].size()));
+        while (nDropped > 0)
+        {
+            pendingOutputSamples[i].pop_front();
+            scheduledAlignmentDrops[i]--;
+            appliedAlignmentDrops[i]++;
+            nDropped--;
+        }
+    }
+}
+
+void Kraken::schedule_alignment_delta_locked(int64_t deltaSamples)
+{
+    if (deltaSamples > 0)
+    {
+        scheduledAlignmentDrops[0] += static_cast<uint64_t>(deltaSamples);
+    }
+    else if (deltaSamples < 0)
+    {
+        scheduledAlignmentDrops[1] += static_cast<uint64_t>(-deltaSamples);
+    }
+
+    drain_scheduled_drops_locked();
+}
+
+bool Kraken::snapshot_recent_history_locked(LagSnapshot *snapshot) const
+{
+    if (snapshot == nullptr || alignmentWindowSamples == 0)
+    {
+        return false;
+    }
+
+    const size_t requiredSamples = kStartupAlignmentAttempts * alignmentWindowSamples;
+    for (size_t i = 0; i < nActiveChannels; i++)
+    {
+        if (historySamples[i].size() < requiredSamples)
+        {
+            return false;
+        }
+    }
+
+    for (size_t i = 0; i < nActiveChannels; i++)
+    {
+        snapshot->channels[i].clear();
+        snapshot->channels[i].reserve(requiredSamples);
+        const size_t startIndex = historySamples[i].size() - requiredSamples;
+        for (size_t sampleIndex = startIndex; sampleIndex < historySamples[i].size(); sampleIndex++)
+        {
+            snapshot->channels[i].push_back(historySamples[i][sampleIndex]);
+        }
+    }
+
+    return true;
+}
+
+Kraken::LagMeasurement Kraken::measure_snapshot_lag(const LagSnapshot &snapshot) const
+{
+    LagMeasurement measurement;
+    const size_t requiredSamples = kStartupAlignmentAttempts * alignmentWindowSamples;
+    if (snapshot.channels[0].size() != requiredSamples
+      || snapshot.channels[1].size() != requiredSamples)
+    {
+        return measurement;
+    }
+
+    std::vector<int64_t> lags;
+    lags.reserve(kStartupAlignmentAttempts);
+    double peakMagnitude = 0.0;
+
+    for (size_t attempt = 0; attempt < kStartupAlignmentAttempts; attempt++)
+    {
+        const size_t offset = attempt * alignmentWindowSamples;
+        std::vector<std::complex<float>> referenceWindow(
+          snapshot.channels[0].begin() + offset,
+          snapshot.channels[0].begin() + offset + alignmentWindowSamples);
+        std::vector<std::complex<float>> surveillanceWindow(
+          snapshot.channels[1].begin() + offset,
+          snapshot.channels[1].begin() + offset + alignmentWindowSamples);
+        const LagEstimate windowLag = estimate_window_lag(referenceWindow,
+          surveillanceWindow);
+        if (!windowLag.valid)
+        {
+            return measurement;
+        }
+        lags.push_back(windowLag.lagSamples);
+        peakMagnitude += windowLag.peakMagnitude;
+    }
+
+    std::vector<int64_t> sortedLags = lags;
+    std::sort(sortedLags.begin(), sortedLags.end());
+    const int64_t medianLag = sortedLags[sortedLags.size() / 2];
+    for (size_t i = 0; i < lags.size(); i++)
+    {
+        if (std::llabs(lags[i] - medianLag) > kLagConsensusToleranceSamples)
+        {
+            return measurement;
+        }
+    }
+
+    measurement.valid = true;
+    measurement.lagSamples = medianLag;
+    measurement.peakMagnitude = peakMagnitude / static_cast<double>(lags.size());
+    measurement.attemptLags = lags;
+    return measurement;
+}
+
+Kraken::LagEstimate Kraken::estimate_window_lag(
+    const std::vector<std::complex<float>> &reference,
+    const std::vector<std::complex<float>> &surveillance)
+{
+    LagEstimate estimate;
+    if (reference.size() != surveillance.size() || reference.size() < 2)
+    {
+        return estimate;
+    }
+
+    const size_t nSamples = reference.size();
+    const size_t fftSize = next_power_of_two(nSamples * 2);
+    std::vector<std::complex<double>> referenceSpectrum(fftSize,
+      std::complex<double>(0.0, 0.0));
+    std::vector<std::complex<double>> surveillanceSpectrum(fftSize,
+      std::complex<double>(0.0, 0.0));
+
+    std::complex<double> referenceMean(0.0, 0.0);
+    std::complex<double> surveillanceMean(0.0, 0.0);
+    for (size_t i = 0; i < nSamples; i++)
+    {
+        referenceMean += static_cast<std::complex<double>>(reference[i]);
+        surveillanceMean += static_cast<std::complex<double>>(surveillance[i]);
+    }
+    referenceMean /= static_cast<double>(nSamples);
+    surveillanceMean /= static_cast<double>(nSamples);
+
+    for (size_t i = 0; i < nSamples; i++)
+    {
+        referenceSpectrum[i] = static_cast<std::complex<double>>(reference[i])
+          - referenceMean;
+        surveillanceSpectrum[i] = static_cast<std::complex<double>>(surveillance[i])
+          - surveillanceMean;
+    }
+
+    fftw_plan referencePlan = fftw_plan_dft_1d(static_cast<int>(fftSize),
+      reinterpret_cast<fftw_complex *>(referenceSpectrum.data()),
+      reinterpret_cast<fftw_complex *>(referenceSpectrum.data()),
+      FFTW_FORWARD, FFTW_ESTIMATE);
+    fftw_plan surveillancePlan = fftw_plan_dft_1d(static_cast<int>(fftSize),
+      reinterpret_cast<fftw_complex *>(surveillanceSpectrum.data()),
+      reinterpret_cast<fftw_complex *>(surveillanceSpectrum.data()),
+      FFTW_FORWARD, FFTW_ESTIMATE);
+    fftw_execute(referencePlan);
+    fftw_execute(surveillancePlan);
+    fftw_destroy_plan(referencePlan);
+    fftw_destroy_plan(surveillancePlan);
+
+    for (size_t i = 0; i < fftSize; i++)
+    {
+        referenceSpectrum[i] *= std::conj(surveillanceSpectrum[i]);
+    }
+
+    fftw_plan inversePlan = fftw_plan_dft_1d(static_cast<int>(fftSize),
+      reinterpret_cast<fftw_complex *>(referenceSpectrum.data()),
+      reinterpret_cast<fftw_complex *>(referenceSpectrum.data()),
+      FFTW_BACKWARD, FFTW_ESTIMATE);
+    fftw_execute(inversePlan);
+    fftw_destroy_plan(inversePlan);
+
+    size_t bestIndex = 0;
+    double bestMagnitude = -1.0;
+    for (size_t i = 0; i < nSamples; i++)
+    {
+        const double magnitude = std::norm(referenceSpectrum[i]);
+        if (magnitude > bestMagnitude)
+        {
+            bestMagnitude = magnitude;
+            bestIndex = i;
+        }
+    }
+    for (size_t i = fftSize - (nSamples - 1); i < fftSize; i++)
+    {
+        const double magnitude = std::norm(referenceSpectrum[i]);
+        if (magnitude > bestMagnitude)
+        {
+            bestMagnitude = magnitude;
+            bestIndex = i;
+        }
+    }
+
+    if (bestMagnitude <= 0.0)
+    {
+        return estimate;
+    }
+
+    estimate.valid = true;
+    estimate.lagSamples = (bestIndex < nSamples)
+      ? static_cast<int64_t>(bestIndex)
+      : static_cast<int64_t>(bestIndex) - static_cast<int64_t>(fftSize);
+    estimate.peakMagnitude = std::sqrt(bestMagnitude);
+    return estimate;
+}
+
+void Kraken::extract_output_chunk_locked(
+    std::vector<std::complex<float>> &referenceChunk,
+    std::vector<std::complex<float>> &surveillanceChunk, size_t maxSamples)
+{
+    if (!alignmentReady)
+    {
+        return;
+    }
+
+    const size_t nPairs = std::min(pendingOutputSamples[0].size(),
+      pendingOutputSamples[1].size());
+    const size_t nEmit = std::min(nPairs, maxSamples);
+    if (nEmit == 0)
+    {
+        return;
+    }
+
+    referenceChunk.reserve(nEmit);
+    surveillanceChunk.reserve(nEmit);
+    for (size_t i = 0; i < nEmit; i++)
+    {
+        referenceChunk.push_back(pendingOutputSamples[0].front());
+        pendingOutputSamples[0].pop_front();
+        surveillanceChunk.push_back(pendingOutputSamples[1].front());
+        pendingOutputSamples[1].pop_front();
+    }
+}
+
+void Kraken::emit_output_chunk(
+    const std::vector<std::complex<float>> &referenceChunk,
+    const std::vector<std::complex<float>> &surveillanceChunk)
+{
+    if (referenceChunk.empty() || referenceChunk.size() != surveillanceChunk.size()
+      || outputBuffers[0] == nullptr || outputBuffers[1] == nullptr)
+    {
+        return;
+    }
+
+    outputBuffers[0]->lock();
+    outputBuffers[1]->lock();
+    for (size_t i = 0; i < referenceChunk.size(); i++)
+    {
+        outputBuffers[0]->push_back({static_cast<double>(referenceChunk[i].real()),
+          static_cast<double>(referenceChunk[i].imag())});
+        outputBuffers[1]->push_back({static_cast<double>(surveillanceChunk[i].real()),
+          static_cast<double>(surveillanceChunk[i].imag())});
+    }
+    outputBuffers[0]->unlock_and_notify();
+    outputBuffers[1]->unlock_and_notify();
+
+    if (saveIq != nullptr && saveIq->load())
+    {
+        write_blah2_iq_samples(referenceChunk.data(), surveillanceChunk.data(),
+          referenceChunk.size());
+    }
+}
+
+size_t Kraken::next_power_of_two(size_t value)
+{
+    size_t power = 1;
+    while (power < value)
+    {
+        power <<= 1;
+    }
+    return power;
+}
+
+double Kraken::lag_samples_to_microseconds(int64_t lagSamples) const
+{
+    if (fs == 0)
+    {
+        return 0.0;
+    }
+    return static_cast<double>(lagSamples) * 1000000.0 / static_cast<double>(fs);
 }
 
 void Kraken::replay(IqData *buffer1, IqData *buffer2, std::string _file, bool _loop)

--- a/src/capture/kraken/Kraken.cpp
+++ b/src/capture/kraken/Kraken.cpp
@@ -422,74 +422,71 @@ void Kraken::alignment_worker()
             }
         }
 
-        if (writeRuntimeMetric)
-        {
-            write_runtime_metric(runtimeMetricSnapshot);
-        }
-
         if (measureLag)
         {
             const LagMeasurement measurement = measure_snapshot_lag(snapshot);
+            bool stopAfterMeasurement = false;
             {
                 std::lock_guard<std::mutex> lock(alignmentMutex);
                 if (stopRequested)
                 {
-                    continue;
+                    stopAfterMeasurement = true;
                 }
-
-                if (!measurement.valid)
+                else if (!measurement.valid)
                 {
                     if (alignmentReady)
                     {
                         std::cout << "[Kraken] Drift recheck could not establish a stable lag estimate; retrying in 1 minute." << std::endl;
                         nextDriftCheckTime = std::chrono::steady_clock::now() + kDriftRetryInterval;
                     }
-                    continue;
-                }
-
-                lastMeasuredRawLagSamples = measurement.lagSamples;
-                rawLagValid = true;
-
-                const int64_t currentCorrection = static_cast<int64_t>(appliedAlignmentDrops[0])
-                  - static_cast<int64_t>(appliedAlignmentDrops[1]);
-                const int64_t correctionDelta = measurement.lagSamples - currentCorrection;
-
-                if (!alignmentReady)
-                {
-                    initialLagSamples = measurement.lagSamples;
-                    schedule_alignment_delta_locked(correctionDelta);
-                    alignmentReady = true;
-                    nextDriftCheckTime = std::chrono::steady_clock::now() + driftCheckInterval;
-                    runtimeMetricDirty = true;
-                    runtimeMetricSnapshot = snapshot_runtime_metric_locked();
-                    runtimeMetricDirty = false;
-                    writeRuntimeMetric = true;
-                    std::cout << "[Kraken] Startup sample-time alignment established at "
-                      << measurement.lagSamples << " samples ("
-                      << lag_samples_to_microseconds(measurement.lagSamples)
-                      << " us)." << std::endl;
-                    alignmentCv.notify_all();
+                    stopAfterMeasurement = true;
                 }
                 else
                 {
-                    nextDriftCheckTime = std::chrono::steady_clock::now() + driftCheckInterval;
-                    runtimeMetricDirty = true;
-                    if (correctionDelta != 0)
+                    lastMeasuredRawLagSamples = measurement.lagSamples;
+                    rawLagValid = true;
+
+                    const int64_t currentCorrection = static_cast<int64_t>(appliedAlignmentDrops[0])
+                      - static_cast<int64_t>(appliedAlignmentDrops[1]);
+                    const int64_t correctionDelta = measurement.lagSamples - currentCorrection;
+
+                    if (!alignmentReady)
                     {
-                        const int64_t driftFromInitial = measurement.lagSamples - initialLagSamples;
+                        initialLagSamples = measurement.lagSamples;
                         schedule_alignment_delta_locked(correctionDelta);
-                        std::cout << "[Kraken] Sample-time drift detected: current difference "
+                        alignmentReady = true;
+                        nextDriftCheckTime = std::chrono::steady_clock::now() + driftCheckInterval;
+                        runtimeMetricDirty = true;
+                        runtimeMetricSnapshot = snapshot_runtime_metric_locked();
+                        runtimeMetricDirty = false;
+                        writeRuntimeMetric = true;
+                        std::cout << "[Kraken] Startup sample-time alignment established at "
                           << measurement.lagSamples << " samples ("
                           << lag_samples_to_microseconds(measurement.lagSamples)
-                          << " us), drift from initial " << driftFromInitial
-                          << " samples (" << lag_samples_to_microseconds(driftFromInitial)
                           << " us)." << std::endl;
                         alignmentCv.notify_all();
                     }
+                    else
+                    {
+                        nextDriftCheckTime = std::chrono::steady_clock::now() + driftCheckInterval;
+                        runtimeMetricDirty = true;
+                        if (correctionDelta != 0)
+                        {
+                            const int64_t driftFromInitial = measurement.lagSamples - initialLagSamples;
+                            schedule_alignment_delta_locked(correctionDelta);
+                            std::cout << "[Kraken] Sample-time drift detected: current difference "
+                              << measurement.lagSamples << " samples ("
+                              << lag_samples_to_microseconds(measurement.lagSamples)
+                              << " us), drift from initial " << driftFromInitial
+                              << " samples (" << lag_samples_to_microseconds(driftFromInitial)
+                              << " us)." << std::endl;
+                            alignmentCv.notify_all();
+                        }
 
-                    runtimeMetricSnapshot = snapshot_runtime_metric_locked();
-                    runtimeMetricDirty = false;
-                    writeRuntimeMetric = true;
+                        runtimeMetricSnapshot = snapshot_runtime_metric_locked();
+                        runtimeMetricDirty = false;
+                        writeRuntimeMetric = true;
+                    }
                 }
             }
 
@@ -497,7 +494,18 @@ void Kraken::alignment_worker()
             {
                 write_runtime_metric(runtimeMetricSnapshot);
             }
+
+            if (stopAfterMeasurement)
+            {
+                continue;
+            }
+
             continue;
+        }
+
+        if (writeRuntimeMetric)
+        {
+            write_runtime_metric(runtimeMetricSnapshot);
         }
 
         if (!referenceChunk.empty())

--- a/src/capture/kraken/Kraken.h
+++ b/src/capture/kraken/Kraken.h
@@ -109,8 +109,32 @@ private:
   /// @brief Maximum pending aligned samples retained per channel.
   size_t pendingOutputCapacitySamples = 0;
 
+  /// @brief Number of recent windows used to establish alignment consensus.
+  size_t alignmentWindowCount = 3;
+
+  /// @brief Maximum allowed lag spread between alignment windows.
+  int64_t lagConsensusToleranceSamples = 16;
+
+  /// @brief Period between drift rechecks after startup alignment.
+  std::chrono::minutes driftCheckInterval = std::chrono::minutes(10);
+
   /// @brief Raw startup lag estimate retained as the drift baseline.
   int64_t initialLagSamples = 0;
+
+  /// @brief Most recent measured raw lag before applying any new correction.
+  int64_t lastMeasuredRawLagSamples = 0;
+
+  /// @brief True when a raw lag measurement has been established.
+  bool rawLagValid = false;
+
+  /// @brief Metric file path for local runtime monitoring.
+  std::string runtimeMetricPath;
+
+  /// @brief True when the local runtime metric should be rewritten.
+  bool runtimeMetricDirty = false;
+
+  /// @brief True once metric-file write failures have been reported.
+  bool runtimeMetricWriteWarned = false;
 
   /// @brief Deadline for the next drift recheck.
   std::chrono::steady_clock::time_point nextDriftCheckTime;
@@ -136,6 +160,17 @@ private:
   struct LagSnapshot
   {
     std::vector<std::complex<float>> channels[nActiveChannels];
+  };
+
+  /// @brief Snapshot of the local alignment runtime metric.
+  struct RuntimeMetricSnapshot
+  {
+    bool alignmentReady = false;
+    bool rawLagValid = false;
+    uint64_t updatedAtMs = 0;
+    int64_t currentRawLagSamples = 0;
+    int64_t appliedCorrectionSamples = 0;
+    int64_t driftSamples = 0;
   };
 
   /// @brief Check status of API returns.
@@ -215,6 +250,19 @@ private:
   /// @return Signed lag in microseconds.
   double lag_samples_to_microseconds(int64_t lagSamples) const;
 
+  /// @brief Get the current time in POSIX milliseconds.
+  /// @return Current time in POSIX milliseconds.
+  static uint64_t current_time_ms();
+
+  /// @brief Snapshot the current local alignment runtime metric.
+  /// @return Metric snapshot.
+  RuntimeMetricSnapshot snapshot_runtime_metric_locked() const;
+
+  /// @brief Persist the local alignment runtime metric to disk.
+  /// @param snapshot Metric snapshot to persist.
+  /// @return Void.
+  void write_runtime_metric(const RuntimeMetricSnapshot &snapshot);
+
   friend struct KrakenTestAccess;
 
   /// @brief Callback function when buffer is filled.
@@ -231,7 +279,9 @@ public:
   /// @param path Path to save IQ data.
   /// @return The object.
   Kraken(std::string type, uint32_t fc, uint32_t fs, std::string path, 
-    std::atomic<bool> *saveIq, std::vector<double> gain);
+    std::atomic<bool> *saveIq, std::vector<double> gain,
+    size_t alignmentWindowCount, int64_t lagConsensusToleranceSamples,
+    std::chrono::minutes driftCheckInterval);
 
   /// @brief Implement capture function on KrakenSDR.
   /// @param buffer Pointers to buffers for each channel.

--- a/src/capture/kraken/Kraken.h
+++ b/src/capture/kraken/Kraken.h
@@ -100,6 +100,9 @@ private:
   /// @brief True once startup alignment has completed and aligned samples may flow downstream.
   bool alignmentReady = false;
 
+  /// @brief Enable startup alignment and periodic drift correction.
+  bool alignmentEnabled = true;
+
   /// @brief Number of samples per lag-estimation window.
   size_t alignmentWindowSamples = 0;
 
@@ -279,7 +282,7 @@ public:
   /// @param path Path to save IQ data.
   /// @return The object.
   Kraken(std::string type, uint32_t fc, uint32_t fs, std::string path, 
-    std::atomic<bool> *saveIq, std::vector<double> gain,
+    std::atomic<bool> *saveIq, std::vector<double> gain, bool alignmentEnabled,
     size_t alignmentWindowCount, int64_t lagConsensusToleranceSamples,
     std::chrono::minutes driftCheckInterval);
 

--- a/src/capture/kraken/Kraken.h
+++ b/src/capture/kraken/Kraken.h
@@ -18,19 +18,27 @@
 #include "capture/Source.h"
 #include "data/IqData.h"
 
+#include <chrono>
+#include <condition_variable>
 #include <complex>
 #include <cstddef>
+#include <deque>
+#include <mutex>
 #include <stdint.h>
 #include <string>
 #include <vector>
 #include <rtl-sdr.h>
 
+struct KrakenTestAccess;
+
 class Kraken : public Source
 {
 private:
 
+  static constexpr size_t nActiveChannels = 2;
+
   /// @brief Individual RTL-SDR devices.
-  rtlsdr_dev_t* devs[5];
+  rtlsdr_dev_t* devs[5] = {nullptr, nullptr, nullptr, nullptr, nullptr};
 
   /// @brief Device indices for Kraken.
   std::vector<int> channelIndex;
@@ -49,6 +57,68 @@ private:
   /// @brief Context data passed into each Kraken callback.
   CallbackContext callbackContexts[2];
 
+  /// @brief Shared output buffers for the aligned reference and surveillance streams.
+  IqData *outputBuffers[nActiveChannels] = {nullptr, nullptr};
+
+  /// @brief Protects alignment state shared across callback and worker threads.
+  std::mutex alignmentMutex;
+
+  /// @brief Wakes the alignment worker when fresh raw samples arrive.
+  std::condition_variable alignmentCv;
+
+  /// @brief Pending raw samples awaiting startup alignment or later drift correction.
+  std::deque<std::complex<float>> pendingOutputSamples[nActiveChannels];
+
+  /// @brief Recent raw sample history used for startup alignment and drift rechecks.
+  std::deque<std::complex<float>> historySamples[nActiveChannels];
+
+  /// @brief Alignment drops queued for future callbacks when not enough samples are buffered yet.
+  uint64_t scheduledAlignmentDrops[nActiveChannels] = {0, 0};
+
+  /// @brief Total alignment drops already applied to each channel.
+  uint64_t appliedAlignmentDrops[nActiveChannels] = {0, 0};
+
+  /// @brief True once the capture worker should stop processing.
+  bool stopRequested = false;
+
+  /// @brief True once startup alignment has completed and aligned samples may flow downstream.
+  bool alignmentReady = false;
+
+  /// @brief Number of samples per lag-estimation window.
+  size_t alignmentWindowSamples = 0;
+
+  /// @brief Number of raw history samples retained per channel.
+  size_t historyCapacitySamples = 0;
+
+  /// @brief Raw startup lag estimate retained as the drift baseline.
+  int64_t initialLagSamples = 0;
+
+  /// @brief Deadline for the next drift recheck.
+  std::chrono::steady_clock::time_point nextDriftCheckTime;
+
+  /// @brief Single-window lag estimate.
+  struct LagEstimate
+  {
+    bool valid = false;
+    int64_t lagSamples = 0;
+    double peakMagnitude = 0.0;
+  };
+
+  /// @brief Multi-window lag estimate used to establish startup certainty.
+  struct LagMeasurement
+  {
+    bool valid = false;
+    int64_t lagSamples = 0;
+    double peakMagnitude = 0.0;
+    std::vector<int64_t> attemptLags;
+  };
+
+  /// @brief Snapshot of recent raw IQ windows for lag estimation.
+  struct LagSnapshot
+  {
+    std::vector<std::complex<float>> channels[nActiveChannels];
+  };
+
   /// @brief Check status of API returns.
   /// @param status Return code of API call.
   /// @param message Message if API call error.
@@ -61,6 +131,72 @@ private:
   /// @param nComplexSamples Number of IQ samples in this callback.
   void append_save_samples(size_t channelIndex, const int8_t *samples,
     size_t nComplexSamples);
+
+  /// @brief Append raw callback samples into the alignment and history queues.
+  /// @param channelIndex Zero-based channel index.
+  /// @param samples Pointer to interleaved IQ byte samples.
+  /// @param nComplexSamples Number of IQ samples in this callback.
+  /// @return Void.
+  void append_input_samples(size_t channelIndex, const int8_t *samples,
+    size_t nComplexSamples);
+
+  /// @brief Run startup alignment and periodic drift rechecks.
+  /// @return Void.
+  void alignment_worker();
+
+  /// @brief Drop any queued correction samples that now have backing data.
+  /// @return Void.
+  void drain_scheduled_drops_locked();
+
+  /// @brief Queue a signed alignment correction on the earlier channel.
+  /// @param deltaSamples Positive when channel 1 lags channel 0.
+  /// @return Void.
+  void schedule_alignment_delta_locked(int64_t deltaSamples);
+
+  /// @brief Copy a recent raw history snapshot for lag estimation.
+  /// @param snapshot Destination snapshot.
+  /// @return True when enough history was available.
+  bool snapshot_recent_history_locked(LagSnapshot *snapshot) const;
+
+  /// @brief Estimate lag across several recent windows.
+  /// @param snapshot Raw IQ windows.
+  /// @return Consensus lag measurement.
+  LagMeasurement measure_snapshot_lag(const LagSnapshot &snapshot) const;
+
+  /// @brief Estimate lag from a single pair of IQ windows.
+  /// @param reference Reference channel IQ window.
+  /// @param surveillance Surveillance channel IQ window.
+  /// @return Single-window lag estimate.
+  static LagEstimate estimate_window_lag(
+    const std::vector<std::complex<float>> &reference,
+    const std::vector<std::complex<float>> &surveillance);
+
+  /// @brief Copy one aligned output chunk out of the pending queues.
+  /// @param referenceChunk Destination reference chunk.
+  /// @param surveillanceChunk Destination surveillance chunk.
+  /// @param maxSamples Maximum pairs to extract in one chunk.
+  /// @return Void.
+  void extract_output_chunk_locked(std::vector<std::complex<float>> &referenceChunk,
+    std::vector<std::complex<float>> &surveillanceChunk, size_t maxSamples);
+
+  /// @brief Emit an aligned output chunk into live buffers and optional IQ save.
+  /// @param referenceChunk Reference samples.
+  /// @param surveillanceChunk Surveillance samples.
+  /// @return Void.
+  void emit_output_chunk(const std::vector<std::complex<float>> &referenceChunk,
+    const std::vector<std::complex<float>> &surveillanceChunk);
+
+  /// @brief Compute the next power of two greater than or equal to value.
+  /// @param value Input value.
+  /// @return Next power of two.
+  static size_t next_power_of_two(size_t value);
+
+  /// @brief Convert signed lag samples into microseconds.
+  /// @param lagSamples Signed lag in samples.
+  /// @return Signed lag in microseconds.
+  double lag_samples_to_microseconds(int64_t lagSamples) const;
+
+  friend struct KrakenTestAccess;
 
   /// @brief Callback function when buffer is filled.
   /// @param buf Pointer to buffer of IQ data.

--- a/src/capture/kraken/Kraken.h
+++ b/src/capture/kraken/Kraken.h
@@ -22,7 +22,6 @@
 #include <condition_variable>
 #include <complex>
 #include <cstddef>
-#include <deque>
 #include <mutex>
 #include <stdint.h>
 #include <string>
@@ -57,6 +56,23 @@ private:
   /// @brief Context data passed into each Kraken callback.
   CallbackContext callbackContexts[2];
 
+  /// @brief Fixed-capacity sample ring buffer used by Kraken staging.
+  struct SampleRingBuffer
+  {
+    std::vector<std::complex<float>> data;
+    size_t head = 0;
+    size_t length = 0;
+
+    void set_capacity(size_t capacity);
+    void clear();
+    size_t size() const;
+    bool empty() const;
+    size_t append(const std::vector<std::complex<float>> &samples);
+    size_t discard_front(size_t count);
+    bool copy_tail(std::vector<std::complex<float>> *out, size_t count) const;
+    size_t pop_front_into(std::vector<std::complex<float>> *out, size_t count);
+  };
+
   /// @brief Shared output buffers for the aligned reference and surveillance streams.
   IqData *outputBuffers[nActiveChannels] = {nullptr, nullptr};
 
@@ -67,10 +83,10 @@ private:
   std::condition_variable alignmentCv;
 
   /// @brief Pending raw samples awaiting startup alignment or later drift correction.
-  std::deque<std::complex<float>> pendingOutputSamples[nActiveChannels];
+  SampleRingBuffer pendingOutputSamples[nActiveChannels];
 
   /// @brief Recent raw sample history used for startup alignment and drift rechecks.
-  std::deque<std::complex<float>> historySamples[nActiveChannels];
+  SampleRingBuffer historySamples[nActiveChannels];
 
   /// @brief Alignment drops queued for future callbacks when not enough samples are buffered yet.
   uint64_t scheduledAlignmentDrops[nActiveChannels] = {0, 0};
@@ -89,6 +105,9 @@ private:
 
   /// @brief Number of raw history samples retained per channel.
   size_t historyCapacitySamples = 0;
+
+  /// @brief Maximum pending aligned samples retained per channel.
+  size_t pendingOutputCapacitySamples = 0;
 
   /// @brief Raw startup lag estimate retained as the drift baseline.
   int64_t initialLagSamples = 0;

--- a/src/capture/kraken/README.md
+++ b/src/capture/kraken/README.md
@@ -1,0 +1,147 @@
+# Kraken / 2x RTL-SDR Guide for blah2
+
+This guide describes how the `Kraken` capture path works in blah2 when it is used with two RTL-SDR receive channels.
+
+In the current implementation, blah2 uses two live channels only:
+
+- Channel 0 is treated as the reference channel.
+- Channel 1 is treated as the surveillance channel.
+
+The `Kraken` device type covers both KrakenSDR-style shared-clock hardware and a plain 2x RTL-SDR setup that has been wired to share a common clock.
+
+## Hardware Expectations
+
+For a 2x RTL-SDR setup, the two SDR devices are expected to share a common clock.
+
+This is important because standard RTL-SDR devices do not provide a reliable hardware trigger that starts both receivers on the exact same sample. Even if both tuners are configured with the same center frequency and sample rate, the streams will usually begin with an unknown sample offset.
+
+blah2 works around that limitation by aligning the streams from the received IQ itself. That means both the reference and surveillance channels must be able to observe the same correlated signal during alignment. In passive radar terms, the reference channel should see a strong direct-path transmitter signal, and the surveillance channel must also see enough of that same signal for cross-correlation to lock onto it.
+
+If the two devices do not share a common clock, or if the surveillance channel cannot see enough of the same signal as the reference channel, startup alignment may fail, become unstable, or settle to the wrong offset.
+
+## Software Expectations
+
+blah2 will attempt to call `rtlsdr_set_dithering()` when librtlsdr exposes it. This is recommended for shared-clock RTL-SDR operation because disabling PLL dithering can improve phase coherence.
+
+If your librtlsdr build does not expose `rtlsdr_set_dithering()`, blah2 will continue to run and will log a warning once. Alignment can still work, but startup alignment and drift rechecks may be less stable.
+
+## How Startup IQ Alignment Works
+
+Because normal RTL-SDR devices cannot be sample-triggered together, blah2 performs a signal-based startup alignment step before it releases IQ downstream.
+
+The process is:
+
+1. blah2 opens both RTL-SDR devices and starts asynchronous reads on both channels.
+2. Each callback appends raw IQ into per-channel pending and history ring buffers.
+3. If alignment is enabled, blah2 waits until both channels have enough recent history for a lag estimate.
+4. The history requirement is `windowCount * alignmentWindowSamples` samples per channel.
+5. `alignmentWindowSamples` is not a YAML field. It is derived automatically from `capture.fs` and clamped between 65536 and 262144 samples.
+6. blah2 copies the most recent alignment windows from both channels.
+7. For each window, blah2 estimates lag by FFT-based cross-correlation between reference and surveillance IQ.
+8. If the lag estimates agree within `consensusToleranceSamples`, the median lag is accepted as the raw startup offset.
+9. blah2 drops samples on the earlier channel so the two streams line up.
+10. Once the correction has been applied, aligned IQ starts flowing into the rest of the pipeline.
+
+If the windows do not agree closely enough, blah2 keeps collecting more IQ and tries again. This is why startup alignment depends on both channels seeing the same signal clearly enough for correlation.
+
+## Drift Rechecks
+
+After startup alignment, blah2 continues to monitor the raw lag between the two channels.
+
+At every `recheckIntervalMinutes`, it repeats the same lag measurement on recent IQ history. If the measured lag differs from the correction already applied, blah2 schedules another sample drop on the earlier channel.
+
+Important limits:
+
+- This is a best-effort software correction, not a hardware resync.
+- Corrections are implemented by dropping samples on the earlier channel.
+- Failed rechecks are retried later, but they do not guarantee a stable long-term lock.
+
+## Continuous Drift and Detection Risk
+
+Even with a common clock and periodic realignment, there will still be continuous drift between the two receive paths.
+
+That drift matters because passive radar detections depend on a stable relationship between the reference and surveillance signals. If that relationship moves, the ambiguity surface can smear, peaks can weaken or shift, and detections can appear, disappear, or move in ways that are hard to predict.
+
+In practice:
+
+- periodic realignment reduces the error, but does not eliminate it,
+- drift still accumulates between rechecks,
+- the effect on detections depends on transmitter strength, direct-path visibility, SNR, clock quality, USB behavior, and the quality of the shared-clock wiring.
+
+This means the RTL-SDR alignment path should be treated as a workaround for non-triggerable hardware, not as a substitute for a truly synchronous multi-channel receiver.
+
+## YAML Configuration
+
+Configure the Kraken capture path under `capture.device` in the YAML file passed to `blah2 -c`.
+
+Example:
+
+```yaml
+capture:
+  fs: 2000000
+  fc: 204640000
+  device:
+    type: "Kraken"
+    gain: [15.0, 15.0]
+    alignment:
+      enabled: true
+      windowCount: 3
+      consensusToleranceSamples: 16
+      recheckIntervalMinutes: 10
+```
+
+Relevant fields:
+
+- `capture.device.type`: Must be `Kraken`.
+- `capture.fs`: Sample rate in Hz. This also affects the automatically derived alignment window size, so it changes how much history blah2 needs before the first lag estimate.
+- `capture.fc`: Center frequency in Hz. Both channels must be tuned to the same signal environment.
+- `capture.device.gain`: Per-channel tuner gain in dB. blah2 snaps each requested value to the next supported RTL-SDR tuner step.
+- `capture.device.alignment.enabled`: Enables startup sample-time alignment and periodic drift correction. If set to `false`, blah2 forwards the two channels without startup alignment or drift correction.
+- `capture.device.alignment.windowCount`: Number of consecutive windows used for each lag measurement. Larger values demand more agreement and more startup history.
+- `capture.device.alignment.consensusToleranceSamples`: Maximum allowed spread between the per-window lag estimates. Smaller values are stricter. Larger values accept noisier agreement.
+- `capture.device.alignment.recheckIntervalMinutes`: Interval between drift rechecks after startup alignment succeeds.
+
+Related notes:
+
+- `capture.device.array` and `capture.device.boresight` are downstream geometry settings. They do not control the startup IQ alignment logic.
+- `capture.replay` bypasses live RTL-SDR capture and uses a recorded two-channel IQ file instead.
+- When Kraken capture is running, blah2 writes a local runtime metric file named `kraken-alignment-runtime.json` in `save.path`.
+
+## Runtime Metric File
+
+The runtime metric file is intended for local monitoring and troubleshooting. It is not part of the API contract.
+
+The file includes:
+
+- `alignmentReady`: Whether startup alignment has completed.
+- `rawLagValid`: Whether a lag measurement has been established.
+- `currentRawLagSamples`: Most recent measured raw lag.
+- `appliedCorrectionSamples`: Net correction already applied.
+- `driftSamples`: Difference between the latest raw lag and the startup lag baseline.
+
+Positive lag values mean channel 1 is lagging channel 0.
+
+## Troubleshooting
+
+If startup alignment does not complete, check the following first:
+
+- The two RTL-SDR devices really are sharing a common clock.
+- Both channels are tuned to the same transmitter environment.
+- The surveillance channel can see enough of the same signal as the reference channel for cross-correlation.
+- Gain is not so low that the common signal disappears into noise.
+- Gain is not so high that the shared signal is clipping badly.
+
+Typical symptoms:
+
+- Repeated startup messages saying the lag estimate is not stable usually mean the shared signal is too weak, too distorted, or not common enough across both channels.
+- Large or frequent drift corrections usually indicate unstable timing, weak correlation, or poor shared-clock behavior.
+- If you need to bypass this logic during testing, set `capture.device.alignment.enabled: false`.
+
+## Practical Recommendation
+
+For the best chance of usable detections with two RTL-SDR devices:
+
+- share the clock between both dongles,
+- make sure both channels can see the same direct-path signal during alignment,
+- keep the cabling and RF setup stable,
+- treat drift correction as a mitigation step rather than a guarantee.

--- a/test/unit/capture/TestKraken.cpp
+++ b/test/unit/capture/TestKraken.cpp
@@ -1,0 +1,72 @@
+#include "capture/kraken/Kraken.h"
+
+#include <catch2/catch_test_macros.hpp>
+
+#include <cmath>
+#include <complex>
+#include <vector>
+
+struct KrakenTestAccess
+{
+  static auto estimate(const std::vector<std::complex<float>> &reference,
+    const std::vector<std::complex<float>> &surveillance)
+  {
+    return Kraken::estimate_window_lag(reference, surveillance);
+  }
+};
+
+namespace
+{
+std::vector<std::complex<float>> shift_signal(
+  const std::vector<std::complex<float>> &input, int lagSamples)
+{
+  std::vector<std::complex<float>> shifted(input.size(), {0.0f, 0.0f});
+  for (size_t i = 0; i < input.size(); i++)
+  {
+    const int sourceIndex = static_cast<int>(i) - lagSamples;
+    if (sourceIndex >= 0 && sourceIndex < static_cast<int>(input.size()))
+    {
+      shifted[i] = input[static_cast<size_t>(sourceIndex)];
+    }
+  }
+  return shifted;
+}
+
+std::vector<std::complex<float>> make_signal(size_t nSamples)
+{
+  std::vector<std::complex<float>> signal(nSamples, {0.0f, 0.0f});
+  for (size_t i = 0; i < nSamples; i++)
+  {
+    const float sample = static_cast<float>(i);
+    signal[i] = {
+      std::sin(0.017f * sample) + 0.31f * std::cos(0.071f * sample),
+      std::cos(0.023f * sample) - 0.19f * std::sin(0.053f * sample)
+    };
+  }
+  return signal;
+}
+}
+
+TEST_CASE("KrakenLagEstimatorReportsPositiveLagWhenSecondChannelStartsLater", "[capture][kraken]")
+{
+  const int lagSamples = 37;
+  const std::vector<std::complex<float>> reference = make_signal(4096);
+  const std::vector<std::complex<float>> surveillance = shift_signal(reference,
+    lagSamples);
+
+  const auto estimate = KrakenTestAccess::estimate(reference, surveillance);
+  REQUIRE(estimate.valid);
+  CHECK(estimate.lagSamples == lagSamples);
+}
+
+TEST_CASE("KrakenLagEstimatorReportsNegativeLagWhenSecondChannelStartsEarlier", "[capture][kraken]")
+{
+  const int lagSamples = -23;
+  const std::vector<std::complex<float>> reference = make_signal(4096);
+  const std::vector<std::complex<float>> surveillance = shift_signal(reference,
+    lagSamples);
+
+  const auto estimate = KrakenTestAccess::estimate(reference, surveillance);
+  REQUIRE(estimate.valid);
+  CHECK(estimate.lagSamples == lagSamples);
+}


### PR DESCRIPTION
2x RTL-SDR sample-time alignment for shared-clock setups without shared trigger (use a noise source or equivalent startup calibration to establish a common trigger after device start)

This process of alignment is process periodically based on a user controlled interval
It can also be turned on/off from a user controlled config