### PR TITLE
Fixes flagged by code review

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -181,6 +181,19 @@ target_link_libraries(testSource PRIVATE
 set_target_properties(testSource PROPERTIES
   RUNTIME_OUTPUT_DIRECTORY "${PROJECT_BINARY_TEST_UNIT_DIR}")
 
+add_executable(testWienerHopf
+  test/unit/process/clutter/TestWienerHopf.cpp
+  src/process/clutter/WienerHopf.cpp
+  src/data/IqData.cpp
+)
+target_link_libraries(testWienerHopf PRIVATE
+  Catch2::Catch2WithMain
+  armadillo
+  fftw3
+)
+set_target_properties(testWienerHopf PROPERTIES
+  RUNTIME_OUTPUT_DIRECTORY "${PROJECT_BINARY_TEST_UNIT_DIR}")
+
 add_executable(testKraken
   test/unit/capture/TestKraken.cpp
   src/capture/kraken/Kraken.cpp
@@ -237,6 +250,7 @@ add_test(NAME testAmbiguity COMMAND testAmbiguity)
 add_test(NAME testIqData COMMAND testIqData)
 add_test(NAME testTracker COMMAND testTracker)
 add_test(NAME testSource COMMAND testSource)
+add_test(NAME testWienerHopf COMMAND testWienerHopf)
 add_test(NAME testKraken COMMAND testKraken)
 add_test(NAME testDetectionPhaseA COMMAND testDetectionPhaseA)
 add_test(NAME testDetectionPhaseB COMMAND testDetectionPhaseB)

--- a/src/capture/rspduo/RspDuo.cpp
+++ b/src/capture/rspduo/RspDuo.cpp
@@ -496,9 +496,16 @@ unsigned int reset, void *cbContext)
   // write data to file
   if (capture_fg != nullptr && capture_fg->load())
   {
-    saveIqFileLocal->write(reinterpret_cast<char*>(buffer_16_ar), 
+    std::lock_guard<std::mutex> fileLock(saveIqFileMutex);
+    if (!saveIqFileLocal->is_open())
+    {
+      free(buffer_16_ar);
+      return;
+    }
+
+    saveIqFileLocal->write(reinterpret_cast<char*>(buffer_16_ar),
       sizeof(short) * numSamples * 4);
-    
+
     if (!(*saveIqFileLocal))
     {
       std::cout << "Error: stream_b_callback, not enough samples received" << std::endl;

--- a/src/process/clutter/WienerHopf.cpp
+++ b/src/process/clutter/WienerHopf.cpp
@@ -3,6 +3,7 @@
 #include <complex>
 #include <iostream>
 #include <limits>
+#include <memory>
 #include <stdexcept>
 #include <vector>
 
@@ -59,91 +60,92 @@ WienerHopf::WienerHopf(int32_t _delayMin, int32_t _delayMax, uint32_t _nSamples)
   b = arma::cx_vec(nBins);
   w = arma::cx_vec(nBins);
 
-  // compute FFTW plans in constructor
-  dataX = new std::complex<double>[nSamples];
-  dataY = new std::complex<double>[nSamples];
-  dataOutX = new std::complex<double>[nSamples];
-  dataOutY = new std::complex<double>[nSamples];
-  dataA = new std::complex<double>[nSamples];
-  dataB = new std::complex<double>[nSamples];
-  filtX = new std::complex<double>[nFilterSamples];
-  filtW = new std::complex<double>[nFilterSamples];
-  filt = new std::complex<double>[nFilterSamples];
-  fftX = fftw_plan_dft_1d(static_cast<int>(nSamples), reinterpret_cast<fftw_complex *>(dataX),
-                          reinterpret_cast<fftw_complex *>(dataOutX), FFTW_FORWARD, FFTW_ESTIMATE);
-  fftY = fftw_plan_dft_1d(static_cast<int>(nSamples), reinterpret_cast<fftw_complex *>(dataY),
-                          reinterpret_cast<fftw_complex *>(dataOutY), FFTW_FORWARD, FFTW_ESTIMATE);
-  fftA = fftw_plan_dft_1d(static_cast<int>(nSamples), reinterpret_cast<fftw_complex *>(dataA),
-                          reinterpret_cast<fftw_complex *>(dataA), FFTW_BACKWARD, FFTW_ESTIMATE);
-  fftB = fftw_plan_dft_1d(static_cast<int>(nSamples), reinterpret_cast<fftw_complex *>(dataB),
-                          reinterpret_cast<fftw_complex *>(dataB), FFTW_BACKWARD, FFTW_ESTIMATE);
-  fftFiltX = fftw_plan_dft_1d(static_cast<int>(nFilterSamples), reinterpret_cast<fftw_complex *>(filtX),
-                              reinterpret_cast<fftw_complex *>(filtX), FFTW_FORWARD, FFTW_ESTIMATE);
-  fftFiltW = fftw_plan_dft_1d(static_cast<int>(nFilterSamples), reinterpret_cast<fftw_complex *>(filtW),
-                              reinterpret_cast<fftw_complex *>(filtW), FFTW_FORWARD, FFTW_ESTIMATE);
-  fftFilt = fftw_plan_dft_1d(static_cast<int>(nFilterSamples), reinterpret_cast<fftw_complex *>(filt),
-                             reinterpret_cast<fftw_complex *>(filt), FFTW_BACKWARD, FFTW_ESTIMATE);
+  // Build allocation/plan state with local RAII buffers first. If any step
+  // throws before ownership transfer, partially allocated buffers are freed.
+  auto dataXLocal = std::make_unique<std::complex<double>[]>(nSamples);
+  auto dataYLocal = std::make_unique<std::complex<double>[]>(nSamples);
+  auto dataOutXLocal = std::make_unique<std::complex<double>[]>(nSamples);
+  auto dataOutYLocal = std::make_unique<std::complex<double>[]>(nSamples);
+  auto dataALocal = std::make_unique<std::complex<double>[]>(nSamples);
+  auto dataBLocal = std::make_unique<std::complex<double>[]>(nSamples);
+  auto filtXLocal = std::make_unique<std::complex<double>[]>(nFilterSamples);
+  auto filtWLocal = std::make_unique<std::complex<double>[]>(nFilterSamples);
+  auto filtLocal = std::make_unique<std::complex<double>[]>(nFilterSamples);
 
-  if (fftX == nullptr || fftY == nullptr || fftA == nullptr || fftB == nullptr
-    || fftFiltX == nullptr || fftFiltW == nullptr || fftFilt == nullptr)
+  fftw_plan fftXLocal = fftw_plan_dft_1d(static_cast<int>(nSamples),
+    reinterpret_cast<fftw_complex *>(dataXLocal.get()),
+    reinterpret_cast<fftw_complex *>(dataOutXLocal.get()), FFTW_FORWARD, FFTW_ESTIMATE);
+  fftw_plan fftYLocal = fftw_plan_dft_1d(static_cast<int>(nSamples),
+    reinterpret_cast<fftw_complex *>(dataYLocal.get()),
+    reinterpret_cast<fftw_complex *>(dataOutYLocal.get()), FFTW_FORWARD, FFTW_ESTIMATE);
+  fftw_plan fftALocal = fftw_plan_dft_1d(static_cast<int>(nSamples),
+    reinterpret_cast<fftw_complex *>(dataALocal.get()),
+    reinterpret_cast<fftw_complex *>(dataALocal.get()), FFTW_BACKWARD, FFTW_ESTIMATE);
+  fftw_plan fftBLocal = fftw_plan_dft_1d(static_cast<int>(nSamples),
+    reinterpret_cast<fftw_complex *>(dataBLocal.get()),
+    reinterpret_cast<fftw_complex *>(dataBLocal.get()), FFTW_BACKWARD, FFTW_ESTIMATE);
+  fftw_plan fftFiltXLocal = fftw_plan_dft_1d(static_cast<int>(nFilterSamples),
+    reinterpret_cast<fftw_complex *>(filtXLocal.get()),
+    reinterpret_cast<fftw_complex *>(filtXLocal.get()), FFTW_FORWARD, FFTW_ESTIMATE);
+  fftw_plan fftFiltWLocal = fftw_plan_dft_1d(static_cast<int>(nFilterSamples),
+    reinterpret_cast<fftw_complex *>(filtWLocal.get()),
+    reinterpret_cast<fftw_complex *>(filtWLocal.get()), FFTW_FORWARD, FFTW_ESTIMATE);
+  fftw_plan fftFiltLocal = fftw_plan_dft_1d(static_cast<int>(nFilterSamples),
+    reinterpret_cast<fftw_complex *>(filtLocal.get()),
+    reinterpret_cast<fftw_complex *>(filtLocal.get()), FFTW_BACKWARD, FFTW_ESTIMATE);
+
+  if (fftXLocal == nullptr || fftYLocal == nullptr || fftALocal == nullptr || fftBLocal == nullptr
+    || fftFiltXLocal == nullptr || fftFiltWLocal == nullptr || fftFiltLocal == nullptr)
   {
-    if (fftX != nullptr)
+    if (fftXLocal != nullptr)
     {
-      fftw_destroy_plan(fftX);
-      fftX = nullptr;
+      fftw_destroy_plan(fftXLocal);
     }
-    if (fftY != nullptr)
+    if (fftYLocal != nullptr)
     {
-      fftw_destroy_plan(fftY);
-      fftY = nullptr;
+      fftw_destroy_plan(fftYLocal);
     }
-    if (fftA != nullptr)
+    if (fftALocal != nullptr)
     {
-      fftw_destroy_plan(fftA);
-      fftA = nullptr;
+      fftw_destroy_plan(fftALocal);
     }
-    if (fftB != nullptr)
+    if (fftBLocal != nullptr)
     {
-      fftw_destroy_plan(fftB);
-      fftB = nullptr;
+      fftw_destroy_plan(fftBLocal);
     }
-    if (fftFiltX != nullptr)
+    if (fftFiltXLocal != nullptr)
     {
-      fftw_destroy_plan(fftFiltX);
-      fftFiltX = nullptr;
+      fftw_destroy_plan(fftFiltXLocal);
     }
-    if (fftFiltW != nullptr)
+    if (fftFiltWLocal != nullptr)
     {
-      fftw_destroy_plan(fftFiltW);
-      fftFiltW = nullptr;
+      fftw_destroy_plan(fftFiltWLocal);
     }
-    if (fftFilt != nullptr)
+    if (fftFiltLocal != nullptr)
     {
-      fftw_destroy_plan(fftFilt);
-      fftFilt = nullptr;
+      fftw_destroy_plan(fftFiltLocal);
     }
-
-    delete[] dataX;
-    dataX = nullptr;
-    delete[] dataY;
-    dataY = nullptr;
-    delete[] dataOutX;
-    dataOutX = nullptr;
-    delete[] dataOutY;
-    dataOutY = nullptr;
-    delete[] dataA;
-    dataA = nullptr;
-    delete[] dataB;
-    dataB = nullptr;
-    delete[] filtX;
-    filtX = nullptr;
-    delete[] filtW;
-    filtW = nullptr;
-    delete[] filt;
-    filt = nullptr;
 
     throw std::runtime_error("WienerHopf failed to create FFTW plans.");
   }
+
+  dataX = dataXLocal.release();
+  dataY = dataYLocal.release();
+  dataOutX = dataOutXLocal.release();
+  dataOutY = dataOutYLocal.release();
+  dataA = dataALocal.release();
+  dataB = dataBLocal.release();
+  filtX = filtXLocal.release();
+  filtW = filtWLocal.release();
+  filt = filtLocal.release();
+
+  fftX = fftXLocal;
+  fftY = fftYLocal;
+  fftA = fftALocal;
+  fftB = fftBLocal;
+  fftFiltX = fftFiltXLocal;
+  fftFiltW = fftFiltWLocal;
+  fftFilt = fftFiltLocal;
 }
 
 WienerHopf::~WienerHopf()

--- a/src/process/clutter/WienerHopf.cpp
+++ b/src/process/clutter/WienerHopf.cpp
@@ -66,6 +66,67 @@ WienerHopf::WienerHopf(int32_t _delayMin, int32_t _delayMax, uint32_t _nSamples)
                               reinterpret_cast<fftw_complex *>(filtW), FFTW_FORWARD, FFTW_ESTIMATE);
   fftFilt = fftw_plan_dft_1d(nBins + nSamples + 1, reinterpret_cast<fftw_complex *>(filt),
                              reinterpret_cast<fftw_complex *>(filt), FFTW_BACKWARD, FFTW_ESTIMATE);
+
+  if (fftX == nullptr || fftY == nullptr || fftA == nullptr || fftB == nullptr
+    || fftFiltX == nullptr || fftFiltW == nullptr || fftFilt == nullptr)
+  {
+    if (fftX != nullptr)
+    {
+      fftw_destroy_plan(fftX);
+      fftX = nullptr;
+    }
+    if (fftY != nullptr)
+    {
+      fftw_destroy_plan(fftY);
+      fftY = nullptr;
+    }
+    if (fftA != nullptr)
+    {
+      fftw_destroy_plan(fftA);
+      fftA = nullptr;
+    }
+    if (fftB != nullptr)
+    {
+      fftw_destroy_plan(fftB);
+      fftB = nullptr;
+    }
+    if (fftFiltX != nullptr)
+    {
+      fftw_destroy_plan(fftFiltX);
+      fftFiltX = nullptr;
+    }
+    if (fftFiltW != nullptr)
+    {
+      fftw_destroy_plan(fftFiltW);
+      fftFiltW = nullptr;
+    }
+    if (fftFilt != nullptr)
+    {
+      fftw_destroy_plan(fftFilt);
+      fftFilt = nullptr;
+    }
+
+    delete[] dataX;
+    dataX = nullptr;
+    delete[] dataY;
+    dataY = nullptr;
+    delete[] dataOutX;
+    dataOutX = nullptr;
+    delete[] dataOutY;
+    dataOutY = nullptr;
+    delete[] dataA;
+    dataA = nullptr;
+    delete[] dataB;
+    dataB = nullptr;
+    delete[] filtX;
+    filtX = nullptr;
+    delete[] filtW;
+    filtW = nullptr;
+    delete[] filt;
+    filt = nullptr;
+
+    throw std::runtime_error("WienerHopf failed to create FFTW plans.");
+  }
 }
 
 WienerHopf::~WienerHopf()

--- a/src/process/clutter/WienerHopf.cpp
+++ b/src/process/clutter/WienerHopf.cpp
@@ -2,6 +2,7 @@
 #include <algorithm>
 #include <complex>
 #include <iostream>
+#include <limits>
 #include <stdexcept>
 #include <vector>
 
@@ -17,10 +18,22 @@ WienerHopf::WienerHopf(int32_t _delayMin, int32_t _delayMax, uint32_t _nSamples)
     throw std::invalid_argument("WienerHopf nSamples must be > 0.");
   }
 
+  const int64_t binCount = static_cast<int64_t>(_delayMax)
+    - static_cast<int64_t>(_delayMin) + 1;
+  if (binCount <= 0
+    || binCount > static_cast<int64_t>(std::numeric_limits<uint32_t>::max()))
+  {
+    throw std::invalid_argument("WienerHopf delay range produces invalid bin count.");
+  }
+  if (static_cast<uint64_t>(binCount) > static_cast<uint64_t>(_nSamples))
+  {
+    throw std::invalid_argument("WienerHopf requires nBins <= nSamples.");
+  }
+
   // input
   delayMin = _delayMin;
   delayMax = _delayMax;
-  nBins = static_cast<uint32_t>(delayMax - delayMin + 1);
+  nBins = static_cast<uint32_t>(binCount);
   nSamples = _nSamples;
 
   // initialise data

--- a/src/process/clutter/WienerHopf.cpp
+++ b/src/process/clutter/WienerHopf.cpp
@@ -192,6 +192,12 @@ bool WienerHopf::process(IqData *x, IqData *y)
 {
   uint32_t i, j;
 
+  if (x == nullptr || y == nullptr)
+  {
+    std::cerr << "WienerHopf requires non-null input buffers." << std::endl;
+    return false;
+  }
+
   if (x->get_length() < nSamples || y->get_length() < nSamples)
   {
     std::cerr << "WienerHopf requires at least " << nSamples
@@ -203,7 +209,13 @@ bool WienerHopf::process(IqData *x, IqData *y)
   // load data from ring-buffers
   for (i = 0; i < nSamples; i++)
   {
-    dataX[i] = x->at_unchecked((((i - delayMin) % nSamples) + nSamples) % nSamples);
+    const int64_t shiftedIndex = static_cast<int64_t>(i)
+      - static_cast<int64_t>(delayMin);
+    const int64_t wrappedIndex =
+      ((shiftedIndex % static_cast<int64_t>(nSamples))
+      + static_cast<int64_t>(nSamples))
+      % static_cast<int64_t>(nSamples);
+    dataX[i] = x->at_unchecked(static_cast<uint32_t>(wrappedIndex));
     dataY[i] = y->at_unchecked(i);
   }
 

--- a/src/process/clutter/WienerHopf.cpp
+++ b/src/process/clutter/WienerHopf.cpp
@@ -30,11 +30,28 @@ WienerHopf::WienerHopf(int32_t _delayMin, int32_t _delayMax, uint32_t _nSamples)
     throw std::invalid_argument("WienerHopf requires nBins <= nSamples.");
   }
 
+  if (_nSamples > static_cast<uint32_t>(std::numeric_limits<int>::max()))
+  {
+    throw std::invalid_argument("WienerHopf nSamples exceeds FFTW int length limit.");
+  }
+
+  const uint64_t filterLen64 = static_cast<uint64_t>(binCount)
+    + static_cast<uint64_t>(_nSamples) + 1ULL;
+  if (filterLen64 > static_cast<uint64_t>(std::numeric_limits<uint32_t>::max()))
+  {
+    throw std::invalid_argument("WienerHopf filter length overflows uint32_t.");
+  }
+  if (filterLen64 > static_cast<uint64_t>(std::numeric_limits<int>::max()))
+  {
+    throw std::invalid_argument("WienerHopf filter length exceeds FFTW int length limit.");
+  }
+
   // input
   delayMin = _delayMin;
   delayMax = _delayMax;
   nBins = static_cast<uint32_t>(binCount);
   nSamples = _nSamples;
+  nFilterSamples = static_cast<uint32_t>(filterLen64);
 
   // initialise data
   A = arma::cx_mat(nBins, nBins);
@@ -49,22 +66,22 @@ WienerHopf::WienerHopf(int32_t _delayMin, int32_t _delayMax, uint32_t _nSamples)
   dataOutY = new std::complex<double>[nSamples];
   dataA = new std::complex<double>[nSamples];
   dataB = new std::complex<double>[nSamples];
-  filtX = new std::complex<double>[nBins + nSamples + 1];
-  filtW = new std::complex<double>[nBins + nSamples + 1];
-  filt = new std::complex<double>[nBins + nSamples + 1];
-  fftX = fftw_plan_dft_1d(nSamples, reinterpret_cast<fftw_complex *>(dataX),
+  filtX = new std::complex<double>[nFilterSamples];
+  filtW = new std::complex<double>[nFilterSamples];
+  filt = new std::complex<double>[nFilterSamples];
+  fftX = fftw_plan_dft_1d(static_cast<int>(nSamples), reinterpret_cast<fftw_complex *>(dataX),
                           reinterpret_cast<fftw_complex *>(dataOutX), FFTW_FORWARD, FFTW_ESTIMATE);
-  fftY = fftw_plan_dft_1d(nSamples, reinterpret_cast<fftw_complex *>(dataY),
+  fftY = fftw_plan_dft_1d(static_cast<int>(nSamples), reinterpret_cast<fftw_complex *>(dataY),
                           reinterpret_cast<fftw_complex *>(dataOutY), FFTW_FORWARD, FFTW_ESTIMATE);
-  fftA = fftw_plan_dft_1d(nSamples, reinterpret_cast<fftw_complex *>(dataA),
+  fftA = fftw_plan_dft_1d(static_cast<int>(nSamples), reinterpret_cast<fftw_complex *>(dataA),
                           reinterpret_cast<fftw_complex *>(dataA), FFTW_BACKWARD, FFTW_ESTIMATE);
-  fftB = fftw_plan_dft_1d(nSamples, reinterpret_cast<fftw_complex *>(dataB),
+  fftB = fftw_plan_dft_1d(static_cast<int>(nSamples), reinterpret_cast<fftw_complex *>(dataB),
                           reinterpret_cast<fftw_complex *>(dataB), FFTW_BACKWARD, FFTW_ESTIMATE);
-  fftFiltX = fftw_plan_dft_1d(nBins + nSamples + 1, reinterpret_cast<fftw_complex *>(filtX),
+  fftFiltX = fftw_plan_dft_1d(static_cast<int>(nFilterSamples), reinterpret_cast<fftw_complex *>(filtX),
                               reinterpret_cast<fftw_complex *>(filtX), FFTW_FORWARD, FFTW_ESTIMATE);
-  fftFiltW = fftw_plan_dft_1d(nBins + nSamples + 1, reinterpret_cast<fftw_complex *>(filtW),
+  fftFiltW = fftw_plan_dft_1d(static_cast<int>(nFilterSamples), reinterpret_cast<fftw_complex *>(filtW),
                               reinterpret_cast<fftw_complex *>(filtW), FFTW_FORWARD, FFTW_ESTIMATE);
-  fftFilt = fftw_plan_dft_1d(nBins + nSamples + 1, reinterpret_cast<fftw_complex *>(filt),
+  fftFilt = fftw_plan_dft_1d(static_cast<int>(nFilterSamples), reinterpret_cast<fftw_complex *>(filt),
                              reinterpret_cast<fftw_complex *>(filt), FFTW_BACKWARD, FFTW_ESTIMATE);
 
   if (fftX == nullptr || fftY == nullptr || fftA == nullptr || fftB == nullptr
@@ -255,7 +272,7 @@ bool WienerHopf::process(IqData *x, IqData *y)
   {
     filtX[i] = dataX[i];
   }
-  for (i = nSamples; i < nBins + nSamples + 1; i++)
+  for (i = nSamples; i < nFilterSamples; i++)
   {
     filtX[i] = {0, 0};
   }
@@ -265,7 +282,7 @@ bool WienerHopf::process(IqData *x, IqData *y)
   {
     filtW[i] = w[i];
   }
-  for (i = nBins; i < nBins + nSamples + 1; i++)
+  for (i = nBins; i < nFilterSamples; i++)
   {
     filtW[i] = {0, 0};
   }
@@ -275,7 +292,7 @@ bool WienerHopf::process(IqData *x, IqData *y)
   fftw_execute(fftFiltW);
 
   // compute convolution/filter
-  for (i = 0; i < nBins + nSamples + 1; i++)
+  for (i = 0; i < nFilterSamples; i++)
   {
     filt[i] = (filtW[i] * filtX[i]);
   }
@@ -285,7 +302,7 @@ bool WienerHopf::process(IqData *x, IqData *y)
   y->clear();
   for (i = 0; i < nSamples; i++)
   {
-    y->push_back(dataY[i] - (filt[i] / (double)(nBins + nSamples + 1)));
+    y->push_back(dataY[i] - (filt[i] / (double)nFilterSamples));
   }
 
   return true;

--- a/src/process/clutter/WienerHopf.cpp
+++ b/src/process/clutter/WienerHopf.cpp
@@ -2,15 +2,25 @@
 #include <algorithm>
 #include <complex>
 #include <iostream>
+#include <stdexcept>
 #include <vector>
 
 // constructor
 WienerHopf::WienerHopf(int32_t _delayMin, int32_t _delayMax, uint32_t _nSamples)
 {
+  if (_delayMax < _delayMin)
+  {
+    throw std::invalid_argument("WienerHopf delayMax must be >= delayMin.");
+  }
+  if (_nSamples == 0)
+  {
+    throw std::invalid_argument("WienerHopf nSamples must be > 0.");
+  }
+
   // input
   delayMin = _delayMin;
   delayMax = _delayMax;
-  nBins = delayMax - delayMin;
+  nBins = static_cast<uint32_t>(delayMax - delayMin + 1);
   nSamples = _nSamples;
 
   // initialise data
@@ -47,13 +57,44 @@ WienerHopf::WienerHopf(int32_t _delayMin, int32_t _delayMax, uint32_t _nSamples)
 
 WienerHopf::~WienerHopf()
 {
-  fftw_destroy_plan(fftX);
-  fftw_destroy_plan(fftY);
-  fftw_destroy_plan(fftA);
-  fftw_destroy_plan(fftB);
-  fftw_destroy_plan(fftFiltX);
-  fftw_destroy_plan(fftFiltW);
-  fftw_destroy_plan(fftFilt);
+  if (fftX != nullptr)
+  {
+    fftw_destroy_plan(fftX);
+  }
+  if (fftY != nullptr)
+  {
+    fftw_destroy_plan(fftY);
+  }
+  if (fftA != nullptr)
+  {
+    fftw_destroy_plan(fftA);
+  }
+  if (fftB != nullptr)
+  {
+    fftw_destroy_plan(fftB);
+  }
+  if (fftFiltX != nullptr)
+  {
+    fftw_destroy_plan(fftFiltX);
+  }
+  if (fftFiltW != nullptr)
+  {
+    fftw_destroy_plan(fftFiltW);
+  }
+  if (fftFilt != nullptr)
+  {
+    fftw_destroy_plan(fftFilt);
+  }
+
+  delete[] dataX;
+  delete[] dataY;
+  delete[] dataOutX;
+  delete[] dataOutY;
+  delete[] dataA;
+  delete[] dataB;
+  delete[] filtX;
+  delete[] filtW;
+  delete[] filt;
 }
 
 bool WienerHopf::process(IqData *x, IqData *y)
@@ -91,7 +132,8 @@ bool WienerHopf::process(IqData *x, IqData *y)
   }
   A = arma::toeplitz(a);
 
-  const double diagonalLoading = std::max(1e-12, 1e-6 * std::abs(a[0]));
+  const double diagonalLoading = std::max(1e-12,
+    1e-6 * (nBins > 0 ? std::abs(a[0]) : 0.0));
   for (i = 0; i < nBins; i++)
   {
     A(i, i) += diagonalLoading;

--- a/src/process/clutter/WienerHopf.h
+++ b/src/process/clutter/WienerHopf.h
@@ -13,6 +13,7 @@
 #include <stdint.h>
 #include <fftw3.h>
 #include <armadillo>
+#include <complex>
 
 class WienerHopf
 {
@@ -34,12 +35,26 @@ private:
 
   /// @brief FFTW plans for clutter filter processing.
   /// @{
-  fftw_plan fftX, fftY, fftA, fftB, fftFiltX, fftFiltW, fftFilt;
+  fftw_plan fftX = nullptr;
+  fftw_plan fftY = nullptr;
+  fftw_plan fftA = nullptr;
+  fftw_plan fftB = nullptr;
+  fftw_plan fftFiltX = nullptr;
+  fftw_plan fftFiltW = nullptr;
+  fftw_plan fftFilt = nullptr;
   /// @}
 
   /// @brief FFTW storage for clutter filter processing.
   /// @{
-  std::complex<double> *dataX, *dataY, *dataOutX, *dataOutY, *dataA, *dataB, *filtX, *filtW, *filt;
+  std::complex<double> *dataX = nullptr;
+  std::complex<double> *dataY = nullptr;
+  std::complex<double> *dataOutX = nullptr;
+  std::complex<double> *dataOutY = nullptr;
+  std::complex<double> *dataA = nullptr;
+  std::complex<double> *dataB = nullptr;
+  std::complex<double> *filtX = nullptr;
+  std::complex<double> *filtW = nullptr;
+  std::complex<double> *filt = nullptr;
   /// @}
 
   /// @brief Autocorrelation toeplitz matrix.

--- a/src/process/clutter/WienerHopf.h
+++ b/src/process/clutter/WienerHopf.h
@@ -30,6 +30,9 @@ private:
   /// @brief Number of samples per CPI.
   uint32_t nSamples;
 
+  /// @brief FFT length used for clutter convolution/filter operations.
+  uint32_t nFilterSamples;
+
   /// @brief True if clutter filter processing is successful.
   bool success;
 

--- a/src/process/clutter/WienerHopf.h
+++ b/src/process/clutter/WienerHopf.h
@@ -84,6 +84,11 @@ public:
   /// @return Void.
   ~WienerHopf();
 
+  WienerHopf(const WienerHopf &) = delete;
+  WienerHopf &operator=(const WienerHopf &) = delete;
+  WienerHopf(WienerHopf &&) = delete;
+  WienerHopf &operator=(WienerHopf &&) = delete;
+
   /// @brief Implement the clutter filter.
   /// @param x Reference samples.
   /// @param y Surveillance samples.

--- a/test/unit/process/clutter/TestWienerHopf.cpp
+++ b/test/unit/process/clutter/TestWienerHopf.cpp
@@ -19,6 +19,11 @@ TEST_CASE("WienerHopfConstructorRejectsZeroSamples", "[process][clutter]")
   CHECK_THROWS_AS(WienerHopf(0, 0, 0), std::invalid_argument);
 }
 
+TEST_CASE("WienerHopfConstructorRejectsBinsLargerThanSamples", "[process][clutter]")
+{
+  CHECK_THROWS_AS(WienerHopf(0, 8, 4), std::invalid_argument);
+}
+
 TEST_CASE("WienerHopfProcessRejectsShortInputs", "[process][clutter]")
 {
   WienerHopf filter(0, 0, 64);

--- a/test/unit/process/clutter/TestWienerHopf.cpp
+++ b/test/unit/process/clutter/TestWienerHopf.cpp
@@ -1,0 +1,29 @@
+/// @file TestWienerHopf.cpp
+/// @brief Unit tests for WienerHopf constructor/runtime guards.
+/// @author GitHub Copilot
+
+#include <catch2/catch_test_macros.hpp>
+
+#include "process/clutter/WienerHopf.h"
+#include "data/IqData.h"
+
+#include <stdexcept>
+
+TEST_CASE("WienerHopfConstructorRejectsInvalidDelayRange", "[process][clutter]")
+{
+  CHECK_THROWS_AS(WienerHopf(3, 2, 64), std::invalid_argument);
+}
+
+TEST_CASE("WienerHopfConstructorRejectsZeroSamples", "[process][clutter]")
+{
+  CHECK_THROWS_AS(WienerHopf(0, 0, 0), std::invalid_argument);
+}
+
+TEST_CASE("WienerHopfProcessRejectsShortInputs", "[process][clutter]")
+{
+  WienerHopf filter(0, 0, 64);
+  IqData reference(64);
+  IqData surveillance(64);
+
+  CHECK(filter.process(&reference, &surveillance) == false);
+}

--- a/test/unit/process/clutter/TestWienerHopf.cpp
+++ b/test/unit/process/clutter/TestWienerHopf.cpp
@@ -7,6 +7,7 @@
 #include "process/clutter/WienerHopf.h"
 #include "data/IqData.h"
 
+#include <limits>
 #include <stdexcept>
 
 TEST_CASE("WienerHopfConstructorRejectsInvalidDelayRange", "[process][clutter]")
@@ -22,6 +23,15 @@ TEST_CASE("WienerHopfConstructorRejectsZeroSamples", "[process][clutter]")
 TEST_CASE("WienerHopfConstructorRejectsBinsLargerThanSamples", "[process][clutter]")
 {
   CHECK_THROWS_AS(WienerHopf(0, 8, 4), std::invalid_argument);
+}
+
+TEST_CASE("WienerHopfConstructorRejectsBinCountOverflow", "[process][clutter]")
+{
+  CHECK_THROWS_AS(
+    WienerHopf(std::numeric_limits<int32_t>::min(),
+      std::numeric_limits<int32_t>::max(),
+      std::numeric_limits<uint32_t>::max()),
+    std::invalid_argument);
 }
 
 TEST_CASE("WienerHopfProcessRejectsShortInputs", "[process][clutter]")

--- a/test/unit/process/clutter/TestWienerHopf.cpp
+++ b/test/unit/process/clutter/TestWienerHopf.cpp
@@ -9,6 +9,12 @@
 
 #include <limits>
 #include <stdexcept>
+#include <type_traits>
+
+static_assert(!std::is_copy_constructible_v<WienerHopf>);
+static_assert(!std::is_copy_assignable_v<WienerHopf>);
+static_assert(!std::is_move_constructible_v<WienerHopf>);
+static_assert(!std::is_move_assignable_v<WienerHopf>);
 
 TEST_CASE("WienerHopfConstructorRejectsInvalidDelayRange", "[process][clutter]")
 {
@@ -53,4 +59,14 @@ TEST_CASE("WienerHopfProcessRejectsShortInputs", "[process][clutter]")
   IqData surveillance(64);
 
   CHECK(filter.process(&reference, &surveillance) == false);
+}
+
+TEST_CASE("WienerHopfProcessRejectsNullInputs", "[process][clutter]")
+{
+  WienerHopf filter(0, 0, 64);
+  IqData reference(64);
+  IqData surveillance(64);
+
+  CHECK(filter.process(nullptr, &surveillance) == false);
+  CHECK(filter.process(&reference, nullptr) == false);
 }

--- a/test/unit/process/clutter/TestWienerHopf.cpp
+++ b/test/unit/process/clutter/TestWienerHopf.cpp
@@ -34,6 +34,18 @@ TEST_CASE("WienerHopfConstructorRejectsBinCountOverflow", "[process][clutter]")
     std::invalid_argument);
 }
 
+TEST_CASE("WienerHopfConstructorRejectsSamplesAboveFftwIntLimit", "[process][clutter]")
+{
+  const uint32_t tooLargeSamples =
+    static_cast<uint32_t>(static_cast<uint64_t>(std::numeric_limits<int>::max()) + 1ULL);
+  CHECK_THROWS_AS(WienerHopf(0, 0, tooLargeSamples), std::invalid_argument);
+}
+
+TEST_CASE("WienerHopfConstructorRejectsFilterLengthUint32Overflow", "[process][clutter]")
+{
+  CHECK_THROWS_AS(WienerHopf(0, 0, std::numeric_limits<uint32_t>::max()), std::invalid_argument);
+}
+
 TEST_CASE("WienerHopfProcessRejectsShortInputs", "[process][clutter]")
 {
   WienerHopf filter(0, 0, 64);


### PR DESCRIPTION
This pull request is to address issues highlighted by a code review for a previous PR.

The focused review on the previous branch found a few high-signal risks worth addressing:

    src/process/clutter/WienerHopf.cpp: nBins is computed as delayMax - delayMin but the class contract/documentation expects inclusive bins (+1), and a[0] is still accessed without guarding the zero-bin case.
    src/process/clutter/WienerHopf.cpp: no validation for delayMax < delayMin; with unsigned nBins this can underflow and trigger huge allocations.
    src/capture/rspduo/RspDuo.cpp: callback file writes use saveIqFileLocal->write(...) without saveIqFileMutex, while Source::close_file() closes under mutex; this leaves a possible write/close race.
    src/process/clutter/WienerHopf.cpp: destructor destroys FFTW plans but does not free heap arrays allocated with new[].

I couldn’t run full/targeted binaries in this sandbox because the configured toolchain/build deps are missing (/scripts/buildsystems/vcpkg.cmake, compilers/make), so the review above is static-analysis based.